### PR TITLE
initial Shelly2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all Shelly1 Shelly25
+.PHONY: all Shelly1 Shelly1PM Shelly25 Shelly2 Shelly-Plug-S
 
 MOS ?= mos
 LOCAL ?= 0
@@ -20,6 +20,9 @@ Shelly1PM: build-Shelly1PM
 	@true
 
 ShellyPlugS: build-ShellyPlugS
+	@true
+
+Shelly25: build-Shelly2
 	@true
 
 Shelly25: build-Shelly25

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq "$(LOCAL)" "1"
 	BUILD_DIR = ./build_$*
 endif
 
-all: Shelly1 Shelly1PM Shelly25 ShellyPlugS
+all: Shelly1 Shelly1PM Shelly2 Shelly25 ShellyPlugS
 
 Shelly1: build-Shelly1
 	@true
@@ -22,7 +22,7 @@ Shelly1PM: build-Shelly1PM
 ShellyPlugS: build-ShellyPlugS
 	@true
 
-Shelly25: build-Shelly2
+Shelly2: build-Shelly2
 	@true
 
 Shelly25: build-Shelly25

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple HomeKit firmware for Shelly switches
 
-This firmware exposes Shelly1, SHelly1PM, ShellyPlug-S and Shelly25 as Apple HomeKit accessories.
+This firmware exposes Shelly1, SHelly1PM, ShellyPlug-S, Shelly2 and Shelly25 as Apple HomeKit accessories.
 
 Firmware is compatible with stock and can be uploaded via OTA (see below) or [flashed via serial connection](docs/flashing.md).
 

--- a/mos.yml
+++ b/mos.yml
@@ -1,6 +1,6 @@
 author: 'Deomid "rojer" Ryabkov'
 description: A HomeKit firmware for Shelly switches
-version: 1.3.3
+version: 1.3.4
 platform: esp8266
 
 libs_version: 2.17.0
@@ -144,6 +144,40 @@ conds:
         - ["sw1.name", "Shelly SW"]
         - ["sw1.out_gpio", 15]
         - ["sw1.in_gpio", 13]
+
+  - when: build_vars.MODEL == "Shelly2"
+    apply:
+      name: switch
+      libs:
+        - origin: https://github.com/mongoose-os-libs/mbedtls
+          variant: esp8266-noatca
+        - origin: https://github.com/mongoose-os-libs/mongoose
+          variant: esp8266-nossl
+      build_vars:
+        FLASH_SIZE: 2097152
+        FS_SIZE: 262144
+        BOOT_CONFIG_ADDR: 0x1000
+        MGOS_ROOT_FS_TYPE: SPIFFS
+        MGOS_MBEDTLS_ENABLE_ATCA: 0
+      cdefs:
+        PRODUCT_MODEL: '"Shelly2"'
+        PRODUCT_HW_REV: '"1.0"'
+        NUM_SWITCHES: 2
+        MG_ENABLE_SSL: 0
+        # HAP_LOG_LEVEL: 0
+      config_schema:
+        - ["device.id", "shellyswitch21-??????"]
+        - ["wifi.ap.ssid", "shellyswitch21-??????"]
+        - ["sw1", "sw", {"title": "SW1 settings"}]
+        - ["sw1.id", 0]
+        - ["sw1.name", "Shelly SW1"]
+        - ["sw1.out_gpio", 4]
+        - ["sw1.in_gpio",  12]
+        - ["sw2", "sw", {"title": "SW2 settings"}]
+        - ["sw2.id", 1]
+        - ["sw2.name", "Shelly SW2"]
+        - ["sw2.out_gpio", 5]
+        - ["sw2.in_gpio",  14]
 
   - when: build_vars.MODEL == "Shelly25"
     apply:

--- a/mos.yml
+++ b/mos.yml
@@ -1,6 +1,6 @@
 author: 'Deomid "rojer" Ryabkov'
 description: A HomeKit firmware for Shelly switches
-version: 1.3.4
+version: 1.4.0
 platform: esp8266
 
 libs_version: 2.17.0


### PR DESCRIPTION
Shelly 2 in relay mode added.

Tested: 
-  manual switches both work as expected
- relays both work as expected
- Reverting back to stock firmware works as expeted..