### PR TITLE
[Flashscript] various fixes and small clean up.

### DIFF
--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -135,7 +135,7 @@ def get_info(host):
       info['colour_mode'] = info['mode']
     else:
       info['colour_mode'] = None
-    info['version'] = info['fw'].split('/v')[1].split('@')[0] if '/v' in info['fw'] else '0.0.0'
+    info['version'] = parseStockVersion(info['fw'])
     info['fw_type'] = 'stock'
     info['fw_type_str'] = 'Official'
     return(info)
@@ -201,6 +201,13 @@ def shelly_model(type):
   }
   return options.get(type, type)
 
+def parseStockVersion(version):
+  # stock version is '20201124-092159/v1.9.0@57ac4ad8', we need '1.9.0'
+  if '/v' in version:
+    parsed_version = version.split('/v')[1].split('@')[0]
+  else:
+    parsed_version = '0.0.0'
+  return (parsed_version)
 
 def parseVersion(vs):
   pp = vs.split('-');
@@ -282,7 +289,7 @@ def write_flash(host, lfw, dlurl, cfw_type, mode, requires_upgrade):
       if mode == 'homekit' and not requires_upgrade:
         onlinecheck = info['version']
       else:
-        onlinecheck = info['fw'].split('/v')[1].split('@')[0] if '/v' in info['fw'] else '0.0.0'
+        onlinecheck = parseStockVersion(info['fw'])
     except (urllib.error.HTTPError, urllib.error.URLError) as err:
       onlinecheck = False
       logger.debug(f"Error: {err}")
@@ -360,12 +367,13 @@ def parse_info(device_info, action, dry_run, silent_run, mode, exclude, version,
         homekit_dlurl = f'http://rojer.me/files/shelly/{version}/shelly-homekit-{model}.zip'
       break
 
-  stock_lfw = stock_release_info['data'][stock_model]['version'].split('/v')[1].split('@')[0]
+  stock_model_info = stock_release_info['data'][stock_model]
+  stock_lfw = parseStockVersion(stock_model_info['version'])
   if not version:
     if device_info['stock_model']  == 'SHRGBW2':
-      stock_dlurl = stock_release_info['data'][stock_model]['url'].replace('.zip','-'+colour_mode+'.zip')
+      stock_dlurl = stock_model_info['url'].replace('.zip','-'+colour_mode+'.zip')
     else:
-      stock_dlurl = stock_release_info['data'][stock_model]['url']
+      stock_dlurl = stock_model_info['url']
   else:
     stock_dlurl = f'http://archive.shelly-faq.de/version/v{version}/{stock_model}.zip'
 

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -333,12 +333,12 @@ def parse_info(device_info, action, dry_run, silent_run, mode, exclude, version,
   logger.debug(f"host: {host}")
   logger.debug(f"device: {device}")
   logger.debug(f"model: {model}")
-  logger.debug(f"stock_model: {device_info['stock_model']}")
+  logger.debug(f"stock_model: {stock_model}")
   logger.debug(f"colour_mode: {colour_mode}")
   logger.debug(f"action: {action}")
   logger.debug(f"dry_run: {dry_run}")
   logger.debug(f"silent_run: {silent_run}")
-  logger.debug(f"mode: {mode}")
+  logger.debug(f"flash mode: {mode}")
   logger.debug(f"exclude: {exclude}")
   logger.debug(f"version: {version}")
   logger.debug(f"variant: {variant}")
@@ -359,7 +359,7 @@ def parse_info(device_info, action, dry_run, silent_run, mode, exclude, version,
         homekit_dlurl = f'http://rojer.me/files/shelly/{version}/shelly-homekit-{model}.zip'
       break
 
-  stock_lfw = stock_release_info['data'][device_info['stock_model']]['version'].split('/v')[1].split('@')[0]
+  stock_lfw = stock_release_info['data'][stock_model]['version'].split('/v')[1].split('@')[0]
   if not version:
     if device_info['stock_model']  == 'SHRGBW2':
       stock_dlurl = stock_release_info['data'][stock_model]['url'].replace('.zip','-'+colour_mode+'.zip')

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -159,6 +159,7 @@ class MyListener:
 
 def shelly_model(type):
   options = {'SHSW-1' : 'Shelly1',
+             'SHSW-L' : 'Shelly1L',
              'SHSW-PM' : 'Shelly1PM',
              'SHSW-21' : 'Shelly2',
              'SHSW-25' : 'Shelly25',

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -67,6 +67,10 @@ logger.setLevel(logging.INFO)
 
 arch = platform.system()
 python_version = float(f"{sys.version_info[0]}.{sys.version_info[1]}")
+if python_version < 3.6:
+  logger.info("Requires python 3.6 or higher.")
+  sys.exit(1)
+
 # Windows does not support acsii colours
 if not arch.startswith('Win'):
   WHITE = '\033[1m'
@@ -533,9 +537,6 @@ if __name__ == '__main__':
   logger.debug(f"verbose: {args.verbose}")
   logger.debug(f"hosts: {args.hosts}")
 
-  if python_version < 3.6:
-    logger.info(F"{WHITE}Requires python 3.6 or higher{NC}")
-    sys.exit(1)
   if not args.hosts and not args.do_all:
     logger.info("Requires a hostname or {-a|--all}.")
     parser.print_help()

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -66,6 +66,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 arch = platform.system()
+python_version = float(f"{sys.version_info[0]}.{sys.version_info[1]}")
 # Windows does not support acsii colours
 if not arch.startswith('Win'):
   WHITE = '\033[1m'
@@ -502,6 +503,7 @@ if __name__ == '__main__':
     logger.setLevel(logging.TRACE)
   logger.debug(f"{WHITE}app{NC}")
   logger.debug(f"{PURPLE}OS: {arch}{NC}")
+  logger.debug(f"{PURPLE}Python Ver: {python_version}{NC}")
   logger.debug(f"action: {action}")
   logger.debug(f"mode: {args.mode}")
   logger.debug(f"do_all: {args.do_all}")
@@ -513,6 +515,10 @@ if __name__ == '__main__':
   logger.debug(f"variant: {args.variant}")
   logger.debug(f"verbose: {args.verbose}")
   logger.debug(f"hosts: {args.hosts}")
+
+  if python_version < 3.6:
+    logger.info(F"{WHITE}Requires python 3.6 or higher{NC}")
+    sys.exit(1)
   if not args.hosts and not args.do_all:
     logger.info("Requires a hostname or {-a|--all}.")
     parser.print_help()

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -371,7 +371,7 @@ def parse_info(device_info, action, dry_run, silent_run, mode, exclude, version,
   stock_lfw = parseStockVersion(stock_model_info['version'])
   if not version:
     if device_info['stock_model']  == 'SHRGBW2':
-      stock_dlurl = stock_model_info['url'].replace('.zip','-'+colour_mode+'.zip')
+      stock_dlurl = stock_model_info['url'].replace('.zip',f'-{colour_mode}.zip')
     else:
       stock_dlurl = stock_model_info['url']
   else:

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -109,9 +109,7 @@ def get_info(host):
       info['model'] = shelly_model(info['app'])
     info['fw_type'] = 'homekit'
     info['fw_type_str'] = 'HomeKit'
-    if info['model']  == 'ShellyRGBW2':
-      info['colour_mode'] = None
-    else:
+    if 'colour_mode' not in info:
       info['colour_mode'] = None
     return(info)
   except (urllib.error.HTTPError) as err:

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -66,11 +66,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 arch = platform.system()
-python_version = float(f"{sys.version_info[0]}.{sys.version_info[1]}")
-if python_version < 3.6:
-  logger.info("Requires python 3.6 or higher.")
-  sys.exit(1)
-
 # Windows does not support acsii colours
 if not arch.startswith('Win'):
   WHITE = '\033[1m'
@@ -524,7 +519,6 @@ if __name__ == '__main__':
     logger.setLevel(logging.TRACE)
   logger.debug(f"{WHITE}app{NC}")
   logger.debug(f"{PURPLE}OS: {arch}{NC}")
-  logger.debug(f"{PURPLE}Python Ver: {python_version}{NC}")
   logger.debug(f"action: {action}")
   logger.debug(f"mode: {args.mode}")
   logger.debug(f"do_all: {args.do_all}")

--- a/tools/flash_shelly.py
+++ b/tools/flash_shelly.py
@@ -267,10 +267,12 @@ def write_flash(host, lfw, dlurl, cfw_type, mode, requires_upgrade):
   n = 1
   waittextshown = False
   info = None
-  while n < 15:
+  while n < 30:
     if waittextshown == False:
-      logger.info(f"waiting for {friendly_host} to reboot")
+      logger.info(f"waiting for {friendly_host} to reboot...")
       waittextshown = True
+    if n == 16:
+      logger.info(f"still waiting for {friendly_host} to reboot...")
     if mode == 'homekit' and not requires_upgrade:
       checkurl = f'http://{host}/rpc/Shelly.GetInfo'
     else:


### PR DESCRIPTION
this adds following:
[FlashScript] add python version check for script, as it requires ver 3.6.x
[FlashScript] add Shelly 1L support.
[FlashScript]  Shelly RGBW2: fix flashing Current Stock firmware.
[FlashScript] small cleanup.
[FlashScript] allow more time to test version, some stock device can take longer than 30 seconds.