### PR TITLE
Load screen

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -20,7 +20,7 @@
     <a class="badge" id="notify_overheat" style="display: none">Overheating</a>
     <a class="badge" id="notify_failsafe" style="display: none">Failsafe mode</a>
   </div>
-  <h1 class="" id="device_name" style="visibility: hidden"></h1>
+  <h1 class="" id="device_name">Loading ...</h1>
 </div>
 
 <div class="container" id="gs_container" style="display: none">
@@ -124,7 +124,7 @@
   </div>
 </div>
 
-<div class="container" id="sys_container">
+<div class="container" id="sys_container" style="display: none">
   <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/System-Settings"
      target="_blank">?</a>
   <h1 class="">System</h1>

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -596,7 +596,6 @@ function updateElement(key, value) {
       break;
     case "name":
       el("device_name").innerText = document.title = value;
-      el("device_name").style.visibility = "visible";
       setValueIfNotModified(el("sys_name"), value);
       break;
     case "wifi_en":
@@ -706,6 +705,9 @@ function getInfo() {
         reject();
         return;
       }
+
+      // always show system information if data is loaded
+      el("sys_container").style.display = "block";
 
       if (data.failsafe_mode) {
         el("notify_failsafe").style.display = "inline";


### PR DESCRIPTION
Before this change the UI looks broken before the first RPC fetch is done, this PR fix it and make it a bit nicer.

Before:
<img width="688" alt="Screenshot 2021-01-22 at 11 51 23" src="https://user-images.githubusercontent.com/165599/105920409-a1442e80-6037-11eb-895a-cf6c6c565bbb.png">

After:
<img width="681" alt="Screenshot 2021-01-22 at 11 52 39" src="https://user-images.githubusercontent.com/165599/105920412-a2755b80-6037-11eb-9760-e8968a22be99.png">

Note: The Donate buttons are still there, I turned of the wifi to make the screenshots, that's why thy are not in the screen shots.