### PR TITLE
fixed #404 adding manual calibration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps/
 releases/
 .DS_Store
 *.zip
+.vscode/

--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -457,6 +457,27 @@
         <span id="cal"></span>
       </div>
       <div class="form-control">
+        <label>Manual Calibration:</label>
+        <label class="switch">
+          <input type="checkbox" id="man_cal">
+          <span class="slider round"></span>
+        </label> 
+        <div id="man_cal_warning">
+          <ion-icon name="warning" 
+            style="vertical-align: text-bottom; font-size: 24px; color: goldenrod;"></ion-icon> Caution
+        </div>
+      </div>
+      <div id="man_cal_settings">
+        <div class="form-control">
+          <label>Movement Time:</label>
+          <input type="text" id="move_time_ms" style="width: 4em; min-width: 2em;"> ms
+        </div>
+        <div class="form-control">
+          <label>Limit Time:</label>
+          <input type="text" id="move_time_limit_pos_ms" style="width: 4em; min-width: 2em;"> ms
+        </div>
+      </div>
+      <div class="form-control">
         <label>Input Mode:</label>
         <select id="in_mode">
           <option id="in_mode_0" value="0">Separate - momentary</option>
@@ -552,5 +573,6 @@
 <script>
 
 </script>
+<script src="https://unpkg.com/ionicons@5.0.0/dist/ionicons.js"></script>
 </body>
 </html>

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -295,6 +295,9 @@ function wcSetConfig(c, cfg, spinner) {
     cfg = {
       name: name,
       in_mode: parseInt(el(c, "in_mode").value),
+      man_cal: el(c, "man_cal").checked,
+      move_time_ms: parseInt(el(c, "move_time_ms").value),
+      move_time_limit_pos_ms: parseInt(el(c, "move_time_limit_pos_ms").value),
       swap_inputs: el(c, "swap_inputs").checked,
       swap_outputs: el(c, "swap_outputs").checked,
     };
@@ -497,9 +500,20 @@ function updateComponent(cd) {
       setValueIfNotModified(el(c, "name"), cd.name);
       el(c, "state").innerText = cd.state_str;
       selectIfNotModified(el(c, "in_mode"), cd.in_mode);
+      checkIfNotModified(el(c, "man_cal"), cd.man_cal);
       checkIfNotModified(el(c, "swap_inputs"), cd.swap_inputs);
       checkIfNotModified(el(c, "swap_outputs"), cd.swap_outputs);
-      if (cd.cal_done == 1) {
+      if(el(c, "man_cal").checked) {
+        el(c, "man_cal_warning").style.display = "inline";
+        el(c, "man_cal_settings").style.display = "block";
+      }
+      else {
+        el(c, "man_cal_warning").style.display = "none";
+        el(c, "man_cal_settings").style.display = "none";
+      }
+      setValueIfNotModified(el(c, "move_time_ms"), cd.move_time_ms);
+      setValueIfNotModified(el(c, "move_time_limit_pos_ms"), cd.move_time_limit_pos_ms);
+      if (cd.cal_done == 1 || cd.man_cal == 1) {
         if (cd.cur_pos != cd.tgt_pos) {
           el(c, "pos").innerText = cd.cur_pos + " -> " + cd.tgt_pos;
         } else {

--- a/mos.yml
+++ b/mos.yml
@@ -66,9 +66,11 @@ config_schema:
   - ["wc.swap_inputs", "b", false, {title: "Swap inputs (2 - open, 1 - close)"}]
   - ["wc.swap_outputs", "b", false, {title: "Swap outputs (2 - open, 1 - close)"}]
   - ["wc.calibrated", "b", false, {title: "Calibration done"}]
+  - ["wc.man_cal", "b", false, {title: "Manual Calibration active"}]
   - ["wc.idle_power_thr", "d", 10.0, {title: "Power consumption threshold for motor idle detection"}]
   - ["wc.move_power", "d", 0.0, {title: "Power consumption during movement, watts"}]
   - ["wc.move_time_ms", "i", 0, {title: "Move time, in millseconds"}]
+  - ["wc.move_time_limit_pos_ms", "i", 0, {title: "Move time to limit position, in milliseconds"}]
   - ["wc.current_pos", "d", 0.0, {title: "Last position, percent: 0 - fully closed, 100 - fully open."}]
 
   - ["gdo", "o", {title: "Garage door settings", abstract: true}]

--- a/src/shelly_hap_window_covering.cpp
+++ b/src/shelly_hap_window_covering.cpp
@@ -37,7 +37,8 @@ WindowCovering::WindowCovering(int id, Input *in0, Input *in1, Output *out0,
       state_timer_(std::bind(&WindowCovering::RunOnce, this)),
       cur_pos_(cfg_->current_pos),
       tgt_pos_(cfg_->current_pos),
-      move_ms_per_pct_(cfg_->move_time_ms / 100.0) {
+      move_ms_per_pct_(cfg_->move_time_ms / 100.0),
+      move_limit_ms_per_pct_(cfg_->move_time_limit_pos_ms / 100.0) {
   if (!cfg_->swap_inputs) {
     in_open_ = in0;
     in_close_ = in1;
@@ -168,7 +169,12 @@ Status WindowCovering::Init() {
   if (cfg_->calibrated) {
     LOG(LL_INFO, ("WC %d: mp %.2f, mt_ms %d, cur_pos %.2f", id(),
                   cfg_->move_power, cfg_->move_time_ms, cur_pos_));
-  } else {
+  } 
+  else if(cfg_->man_cal) {
+    LOG(LL_INFO, ("WC %d: mp %.2f, mt_ms %d, mtlpos_ms %d, cur_pos %.2f", id(),
+      cfg_->move_power, cfg_->move_time_ms, cfg_->move_time_limit_pos_ms, cur_pos_));
+  }
+  else {
     LOG(LL_INFO, ("WC %d: not calibrated", id()));
   }
   state_timer_.Reset(100, MGOS_TIMER_REPEAT);
@@ -194,23 +200,31 @@ StatusOr<std::string> WindowCovering::GetInfoJSON() const {
   return mgos::JSONPrintStringf(
       "{id: %d, type: %d, name: %Q, "
       "in_mode: %d, swap_inputs: %B, swap_outputs: %B, "
-      "cal_done: %B, move_time_ms: %d, move_power: %d, "
+      "cal_done: %B, man_cal: %B, move_time_ms: %d, "
+      "move_time_limit_pos_ms: %d, move_power: %d, "
       "state: %d, state_str: %Q, cur_pos: %d, tgt_pos: %d}",
-      id(), type(), cfg_->name, cfg_->in_mode, cfg_->swap_inputs,
-      cfg_->swap_outputs, cfg_->calibrated, cfg_->move_time_ms,
-      (int) cfg_->move_power, (int) state_, StateStr(state_), (int) cur_pos_,
-      (int) tgt_pos_);
+      id(), type(), cfg_->name, 
+      cfg_->in_mode, cfg_->swap_inputs, cfg_->swap_outputs, 
+      cfg_->calibrated, cfg_->man_cal, cfg_->move_time_ms,
+      cfg_->move_time_limit_pos_ms, (int) cfg_->move_power, 
+      (int) state_, StateStr(state_), (int) cur_pos_, (int) tgt_pos_);
 }
 
 Status WindowCovering::SetConfig(const std::string &config_json,
                                  bool *restart_required) {
   struct mgos_config_wc cfg = *cfg_;
   cfg.name = nullptr;
-  int in_mode = -1;
-  int8_t swap_inputs = -1, swap_outputs = -1;
+  int in_mode = -1, move_time_ms = -1, move_time_limit_pos_ms = -1;
+  int8_t man_cal=-1, swap_inputs = -1, swap_outputs = -1;
   json_scanf(config_json.c_str(), config_json.size(),
-             "{name: %Q, in_mode: %d, swap_inputs: %B, swap_outputs: %B}",
-             &cfg.name, &in_mode, &swap_inputs, &swap_outputs);
+             "{name: %Q, in_mode: %d, "
+             "man_cal: %B, move_time_ms: %d, "
+             "move_time_limit_pos_ms: %d, "
+             "swap_inputs: %B, swap_outputs: %B}",
+             &cfg.name, &in_mode, 
+             &man_cal, &move_time_ms, 
+             &move_time_limit_pos_ms, 
+             &swap_inputs, &swap_outputs);
   mgos::ScopedCPtr name_owner((void *) cfg.name);
   // Validate.
   if (cfg.name != nullptr && strlen(cfg.name) > 64) {
@@ -227,6 +241,21 @@ Status WindowCovering::SetConfig(const std::string &config_json,
   }
   if (in_mode != -1 && in_mode != cfg_->in_mode) {
     cfg_->in_mode = in_mode;
+    *restart_required = true;
+  }
+  if (man_cal != -1 && man_cal != cfg_->man_cal) {
+    cfg_->man_cal = man_cal;
+    if(man_cal && cfg_->calibrated) {
+      cfg_->calibrated = false;
+    }
+    *restart_required = true;
+  }
+  if (move_time_ms != -1 && move_time_ms != cfg_->move_time_ms) {
+    cfg_->move_time_ms = move_time_ms;
+    *restart_required = true;
+  }
+  if (move_time_limit_pos_ms != -1 && move_time_limit_pos_ms != cfg_->move_time_limit_pos_ms) {
+    cfg_->move_time_limit_pos_ms = move_time_limit_pos_ms;
     *restart_required = true;
   }
   if (swap_inputs != -1 && swap_inputs != cfg_->swap_inputs) {
@@ -392,7 +421,7 @@ void WindowCovering::HAPSetTgtPos(float value) {
 WindowCovering::Direction WindowCovering::GetDesiredMoveDirection() {
   if (tgt_pos_ == kNotSet) return Direction::kNone;
   float pos_diff = tgt_pos_ - cur_pos_;
-  if (!cfg_->calibrated || std::abs(pos_diff) < 0.5) {
+  if (!(cfg_->calibrated || cfg_->man_cal) || std::abs(pos_diff) < 0.5) {
     return Direction::kNone;
   }
   return (pos_diff > 0 ? Direction::kOpen : Direction::kClose);
@@ -401,7 +430,7 @@ WindowCovering::Direction WindowCovering::GetDesiredMoveDirection() {
 void WindowCovering::Move(Direction dir) {
   const char *ss = StateStr(state_);
   bool want_open = false, want_close = false;
-  if (cfg_->calibrated) {
+  if (cfg_->calibrated || cfg_->man_cal) {
     switch (dir) {
       case Direction::kNone:
         break;
@@ -497,6 +526,7 @@ void WindowCovering::RunOnce() {
         cfg_->move_time_ms = move_time_ms;
         cfg_->move_power = move_power;
         move_ms_per_pct_ = cfg_->move_time_ms / 100.0;
+        move_limit_ms_per_pct_ = cfg_->move_time_limit_pos_ms / 100.0;
         SetInternalState(State::kPostCal1);
       } else {
         p_sum_ += p1;
@@ -542,7 +572,7 @@ void WindowCovering::RunOnce() {
         break;
       }
       LOG(LL_INFO, ("P = %.2f -> %.2f", p, cfg_->move_power));
-      if (p >= cfg_->move_power * 0.75) {
+      if (cfg_->man_cal || p >= cfg_->move_power * 0.75) {
         SetInternalState(State::kMoving);
         break;
       }
@@ -555,8 +585,22 @@ void WindowCovering::RunOnce() {
       break;
     }
     case State::kMoving: {
+      bool moving_to_limit_pos = (
+          (tgt_pos_ == kFullyOpen && moving_dir_ == Direction::kOpen) 
+        ||
+          (tgt_pos_ == kFullyClosed && moving_dir_ == Direction::kClose)
+        );
       int moving_time_ms = (mgos_uptime_micros() - begin_) / 1000;
-      float pos_diff = moving_time_ms / move_ms_per_pct_;
+      // if manually calibrated move `move_to_end_time_ms` instead of 
+      // `move_time_ms`, in order to really reach the limit 
+      // (Caution: this works for motors, that stop at their limit 
+      // positions by themselves, only).
+      float pos_diff = moving_time_ms / 
+        (moving_to_limit_pos && cfg_->man_cal ? 
+          move_limit_ms_per_pct_ 
+        : 
+          move_ms_per_pct_
+        );
       float new_cur_pos =
           (moving_dir_ == Direction::kOpen ? move_start_pos_ + pos_diff
                                            : move_start_pos_ - pos_diff);
@@ -587,10 +631,11 @@ void WindowCovering::RunOnce() {
       bool reverse =
           (want_move_dir != moving_dir_ && want_move_dir != Direction::kNone);
       // If moving to one of the limit positions, keep moving
-      // until no current is flowing.
-      if (((tgt_pos_ == kFullyOpen && moving_dir_ == Direction::kOpen) ||
-           (tgt_pos_ == kFullyClosed && moving_dir_ == Direction::kClose)) &&
-          !reverse) {
+      // until no current is flowing. But, if manually calibrated
+      // move `move_to_end_time_ms` instead of `move_time_ms`, in order 
+      // to really reach the limit (Caution: this works for motors, that
+      // stop at their limit positions by themselves, only).
+      if (moving_to_limit_pos && !reverse && !cfg_->man_cal) {
         LOG_EVERY_N(LL_INFO, 8, ("Moving to %d, p %.2f", (int) tgt_pos_, p));
         if (p > cfg_->idle_power_thr ||
             (mgos_uptime_micros() - begin_ < 1000000)) {
@@ -605,7 +650,7 @@ void WindowCovering::RunOnce() {
         // Still moving.
         break;
       } else {
-        // We stoped moving. Reconcile target position with current,
+        // We stopped moving. Reconcile target position with current,
         // pretend we wanted to be exactly where we ended up.
         if (std::abs(tgt_pos_ - cur_pos_) < 1) {
           SetTgtPos(cur_pos_, "fixup");
@@ -643,7 +688,7 @@ void WindowCovering::RunOnce() {
 
 void WindowCovering::HandleInputEvent01(Direction dir, Input::Event ev,
                                         bool state) {
-  if (!cfg_->calibrated) {
+  if (!(cfg_->calibrated || cfg_->man_cal)) {
     HandleInputEventNotCalibrated();
     return;
   }
@@ -672,7 +717,7 @@ void WindowCovering::HandleInputEvent01(Direction dir, Input::Event ev,
 }
 
 void WindowCovering::HandleInputEvent2(Input::Event ev, bool state) {
-  if (!cfg_->calibrated) {
+  if (!(cfg_->calibrated || cfg_->man_cal)) {
     HandleInputEventNotCalibrated();
     return;
   }

--- a/src/shelly_hap_window_covering.hpp
+++ b/src/shelly_hap_window_covering.hpp
@@ -138,6 +138,7 @@ class WindowCovering : public Component, public mgos::hap::Service {
   int64_t begin_ = 0;
   float move_start_pos_ = 0;
   float move_ms_per_pct_ = 0;
+  float move_limit_ms_per_pct_ = 0;
   bool obstruction_detected_ = false;
   int64_t last_hap_set_tgt_pos_ = 0;
   Direction moving_dir_ = Direction::kNone;


### PR DESCRIPTION
I added the ability to manually calibrate roller shutters (window closing). This should be used for roller shutters with end position detection, only (should be the case for any motor newer than 25 years). Therefore, a "Caution" hint is added as soon as manual calibration is activated. Two values can be set: (1) the move time. (2) For movements to limit positions a second (i.e., longer) movement time (to limit pos) can be added.