### PR TITLE
Add GitHub action

### DIFF
--- a/.github/version.py
+++ b/.github/version.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+import argparse
+import subprocess
+
+def run(*args):
+    return subprocess.check_output(args).decode('utf-8').strip()
+
+def git_describe(*args):
+    return run('git', 'describe', '--tags', *args)
+
+def git_branch_name():
+    return run('git', 'branch', '--show-current')
+
+def commits_since_forkpoint():
+    return int(run('git', 'rev-list', '--count',  '--no-merges', 'origin/master..'))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Get Shelly-HomeKit version name using Git')
+    parser.add_argument('-s', '--suffix', action='store_true', help='output only the suffix after the version number')
+    parser.add_argument('-r', '--release', action='store_true', help='just use tag number, for stable releases')
+    args, extra_args = parser.parse_known_args()
+
+    # all unknown command line arguments are passed directly to git-describe
+    tag_name, commits_since_tag, extra = git_describe(*extra_args).split(sep='-', maxsplit=2)
+
+    # usually this is just the sha of the git commit
+    # however if e.g. --dirty is passed then, if working tree
+    # dirty, it will be contained in the `info` list
+    info = extra.split('-')
+
+    version = "" if args.suffix else tag_name
+
+    if args.release:
+        print(version)
+        exit()
+
+    branch = git_branch_name()
+    if branch == "master":
+        version += f"-latest{commits_since_tag}"
+    else:
+        # strip dashes from the branch name so it doesn't mess up update
+        version += f"-{branch.replace('-', '')}{commits_since_forkpoint()}"
+
+    # append things like -dirty and -broken,
+    # if passed, to the version name
+    version += '-'.join(['', *info[1:]])
+
+    print(version)

--- a/.github/workflows/shelly-homekit.yaml
+++ b/.github/workflows/shelly-homekit.yaml
@@ -16,11 +16,11 @@ jobs:
           fetch-depth: 0
       - name: Build project
         run: make release RELEASE_SUFFIX=$(.github/version.py --suffix)
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Deploy release artifacts
-        run: echo Not implemented yet
-        shell: bash
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: releases
+          path: |
+            releases/*
+            !releases/**/elf
+          if-no-files-found: error

--- a/.github/workflows/shelly-homekit.yaml
+++ b/.github/workflows/shelly-homekit.yaml
@@ -1,0 +1,26 @@
+name: build-shelly-homekit
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mos build tool
+        run: |
+          sudo add-apt-repository ppa:mongoose-os/mos -y
+          sudo apt -q install mos -y
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build project
+        run: make release RELEASE_SUFFIX=$(.github/version.py --suffix)
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Deploy release artifacts
+        run: echo Not implemented yet
+        shell: bash


### PR DESCRIPTION
* Add a GitHub action that automatically builds firmware for supported Shelly devices (#379)
* Uses `git describe` to put firmware zips into an appropriately-titled directory e.g. `2.7.3-latest8-geee7898` 

View a sample build [here](https://github.com/ZeevoX/shelly-homekit/runs/1788742790).