### PR TITLE
remove unnecessary state read

### DIFF
--- a/src/shelly_switch.cpp
+++ b/src/shelly_switch.cpp
@@ -208,7 +208,6 @@ bool ShellySwitch::GetOutputState() const {
 }
 
 void ShellySwitch::SetOutputState(bool new_state, const char *source) {
-  bool cur_state = out_->GetState();
   out_->SetState(new_state, source);
   if (led_out_ != nullptr) {
     led_out_->SetState((cfg_->state_led_en == 1 && new_state), source);


### PR DESCRIPTION
The result is unused and `GetState` has no side effects, so I assume that is unnecessary.