### PR TITLE
use BTN_NOISY to decide useing NoisyInputPin or InputPin

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -99,6 +99,7 @@ cdefs:
   PRODUCT_MODEL: '"${build_vars.MODEL}"'
   LED_GPIO: -1
   BTN_GPIO: -1
+  BTN_NOISY: 0
   HAP_LOG_LEVEL: 0  # This saves ~44K on esp8266.
 
 libs:
@@ -165,6 +166,7 @@ conds:
         LED_ON: 0
         BTN_GPIO: 13
         BTN_DOWN: 0
+        BTN_NOISY: 1
         PRODUCT_HW_REV: '"1.0"'
         STOCK_FW_MODEL: '"SHSW-L"'
         # We don't use SSL, HomeKit uses its own crypto. This saves ~120K.
@@ -204,6 +206,7 @@ conds:
         LED_ON: 0
         BTN_GPIO: 2
         BTN_DOWN: 0
+        BTN_NOISY: 1
         PRODUCT_HW_REV: '"1.0"'
         STOCK_FW_MODEL: '"SHSW-PM"'
         # We don't use SSL, HomeKit uses its own crypto. This saves ~120K.

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -720,7 +720,7 @@ static void ButtonHandler(Input::Event ev, bool cur_state) {
 static void SetupButton(int pin, bool on_value) {
   if (pin < 0) return;
   s_btn =
-#if CS_PLATFORM == CS_P_ESP8266
+#if BTN_NOISY
       new NoisyInputPin(
 #else
       new InputPin(


### PR DESCRIPTION
At the moment `BTN_GPIO` will configure `SetupButton` which uses `NoisyInputPin` on ESP8266. Thats a problem for the upcoming RGBW2 support. RGBW2 needs PWM and PWM uses the hardware timer, but the hardware timer is blocked by `NoisyInputPin`. 

In a gitter chat @rojer says that only 1L and 1PM needs `NoisyInputPin`, all other can use `InputPin`.

This PR explizit configures the use of `NoisyInputPin` or `InputPin` for `SetupButton`. That allow the `SetupButton` use and PWM on the RGBW2 at the same time.