### PR TITLE
load donate button only once

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -203,7 +203,7 @@
     <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
       <input type="hidden" name="cmd" value="_s-xclick"/>
       <input type="hidden" name="hosted_button_id" value="6KPSKWJDHVLB4"/>
-      <input type="image" id="donate_form_submit" src="" border="0" name="submit" title="Donate via PayPal"
+      <input type="image" id="donate_form_submit" border="0" name="submit" title="Donate via PayPal"
              alt="Donate via PayPal" style="display: none"/>
     </form>
   </div>

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -620,7 +620,9 @@ function updateElement(key, value) {
         el("update_container").style.display = "block";
         el("revert_to_stock_container").style.display = "block";
         // We set external image URL to prevent loading it when not on WiFi, as it slows things down.
-        el("donate_form_submit").src = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif";
+        if (el("donate_form_submit").src == "") {
+          el("donate_form_submit").src = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif";
+        }
         el("donate_form_submit").style.display = "inline";
 
         el("wifi_ip").innerText = "IP: " + value;


### PR DESCRIPTION
Before this change the PayPal donate button was loaded after each web socket response / each sec. With this change it is only loaded once.

<img width="1246" alt="Screenshot 2021-02-07 at 17 47 50" src="https://user-images.githubusercontent.com/165599/107153226-a45ee900-696c-11eb-8f33-79c519b2bdb4.png">
