### PR TITLE
Css cleanup

### DIFF
--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -200,7 +200,6 @@ a.badge {
   border-radius: 50%;
   border-top-color: #fff;
   animation: spin 1s linear infinite;
-  -webkit-animation: spin 1s linear infinite;
   position: absolute;
   top: 0;
   left: 0;
@@ -209,12 +208,6 @@ a.badge {
 @keyframes spin {
   to {
     transform: rotate(360deg);
-  }
-}
-
-@-webkit-keyframes spin {
-  to {
-    -webkit-transform: rotate(360deg);
   }
 }
 
@@ -241,7 +234,6 @@ a.badge {
   right: 0;
   bottom: 0;
   background-color: #ccc;
-  -webkit-transition: .4s;
   transition: .4s;
 }
 
@@ -253,7 +245,6 @@ a.badge {
   left: 4px;
   bottom: 4px;
   background-color: white;
-  -webkit-transition: .4s;
   transition: .4s;
 }
 
@@ -266,8 +257,6 @@ input:focus + .slider {
 }
 
 input:checked + .slider:before {
-  -webkit-transform: translateX(24px);
-  -ms-transform: translateX(24px);
   transform: translateX(24px);
 }
 

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -14,7 +14,7 @@ body {
   font: 14px/1.5 '-apple-system', 'HelveticaNeue', Helvetica, Segoe UI;
 }
 
-h1, h2, h3, h4, h5, h6, b, th, strong, .nav-link {
+h1, h2, h3, h4, h5, h6, b, th, strong {
   color: #454955;
 }
 
@@ -66,24 +66,6 @@ h1 {
   text-align: center;
 }
 
-.header {
-  padding: 0 1em;
-  margin: 1em auto;
-  max-width: 640px;
-  background: #f2f1f6;
-  border-radius: 15px;
-}
-
-.footer {
-  padding: 0 1em;
-  margin: 1em auto;
-  max-width: 640px;
-  background: #f2f1f6;
-  border-radius: 15px;
-  font: 11px '-apple-system', 'HelveticaNeueLight', Helvetica Light, Segoe UI Light;
-  color: #aaaaae;
-}
-
 .container {
   padding: 0 1em;
   margin: 1em auto;
@@ -115,11 +97,6 @@ h1 {
 
 .btn label {
   position: relative;
-}
-
-.btndis {
-  background: #f2f1f6;
-  color: #25282A;
 }
 
 .badge {
@@ -174,13 +151,6 @@ a.badge {
   font: 36px '-apple-system', 'HelveticaNeueLight', Helvetica Light, Segoe UI Light, sans-serif;
   font-weight: lighter;
   text-align: left;
-}
-
-.icon {
-  width: 25px;
-  height: 25px;
-  vertical-align: top;
-  padding-top: 0.28em;
 }
 
 #logo {

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -3,15 +3,12 @@ html, body {
   padding: 0;
   margin: 5;
   background-color: #f2f1f6;
+  color: #454955;
+  font: 14px/1.5 '-apple-system', 'HelveticaNeue', Helvetica, Segoe UI;
 }
 
 * {
   outline: none !important;
-}
-
-body {
-  color: #454955;
-  font: 14px/1.5 '-apple-system', 'HelveticaNeue', Helvetica, Segoe UI;
 }
 
 h1, h2, h3, h4, h5, h6, b, th, strong {
@@ -30,27 +27,12 @@ button {
   cursor: pointer;
 }
 
-a {
-  text-decoration: none;
-  color: #0071e3;
-}
-
-a:link, a:visited {
+a, a:link, a:visited {
   color: #0071e3;
   text-decoration: none;
 }
 
-input[type=password] {
-  width: 160px;
-  padding: 0.2em 0.7em;
-  position: relative;
-  border: 1px solid #cdcdcd;
-  border-color: rgba(0, 0, 0, .15);
-  background-color: #ffffff;
-  font-size: 14px;
-}
-
-input[type=text] {
+input[type=password], input[type=text] {
   width: 160px;
   padding: 0.2em 0.7em;
   position: relative;

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -87,7 +87,9 @@ h1 {
   border-radius: 12px;
   box-shadow: 1px 1px 1px #282828;
   color: #ffffff;
-  font: bold 12px/9px Helvetica, Verdana, Tahoma;
+  font-weight: bold;
+  font-size: 12px;
+  line-height: 9px;
   height: 12px;
   padding: 4px 3px 0 5px;
   text-align: center;
@@ -113,7 +115,9 @@ a.badge {
   border-radius: 12px;
   box-shadow: 1px 1px 0.5px #c1c1c1;
   color: #0071e3 !important;
-  font: bold 14px/10px HelveticaNeueLight, Helvetica, Verdana;
+  font-weight: bold;
+  font: 14px;
+  line-height: 10px;
   height: 13px;
   padding: 6px 6px 1px 6px;
   text-align: center;
@@ -130,9 +134,10 @@ a.badge {
 
 .title {
   color: #454955;
-  font: 36px '-apple-system', 'HelveticaNeueLight', Helvetica Light, Segoe UI Light, sans-serif;
+  font-size: 36px;
   font-weight: lighter;
   text-align: left;
+  line-height: normal;
 }
 
 #logo {

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -60,7 +60,7 @@ h1 {
   margin: 0.6em 0;
 }
 
-.form-control input:not([type="checkbox"]), .form-control button {
+.form-control input:not([type=checkbox]), .form-control button {
   min-width: 10em;
 }
 
@@ -240,6 +240,6 @@ input:checked + .slider:before {
   content: ", ";
 }
 
-.comma-list li:last-child::after {
+.comma-list li:last-child:after {
   content: "";
 }


### PR DESCRIPTION
Remove some css 💩, saves us some bytes.

We don't need the removed vendor prefixes (`-webkit-`/`-ms`) on our supported browsers.

This changes the layout a bit on non apple devises as it's no longer uses the Light variants of the font, but on apple devises they have never been used.

I didn't find any optical change in this PR on latest Mac Safari