### PR TITLE
remove box shadow from help button

### DIFF
--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -113,7 +113,6 @@ a.badge {
   background-color: #fefefe;
   border: 1px solid #999999;
   border-radius: 12px;
-  box-shadow: 1px 1px 0.5px #c1c1c1;
   color: #0071e3 !important;
   font-weight: bold;
   font: 14px;


### PR DESCRIPTION
We use a flat design, for me a drop shadow doesn't fit