### PR TITLE
fix button spinner

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -77,6 +77,9 @@
         <label></label>
         <button id="hap_save_btn">
           <label><span id="hap_save_spinner"></span>Save</label>
+      </div>
+      <div class="form-control">
+        <label></label>
         </button>
         <button id="hap_reset_btn">
           <label><span id="hap_reset_spinner"></span>Reset</label>
@@ -163,6 +166,9 @@
         <button class="btn" id="reboot_btn">
           <label>Reboot</label>
         </button>
+      </div>
+      <div class="form-control">
+        <label></label>
         <button class="btn" id="reset_btn">
           <label>Reset</label>
         </button>

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -31,7 +31,7 @@ button {
 button label {
   position: relative;
   cursor: pointer;
-  min-width: 4em !important;
+  min-width: 10em;
 }
 
 a, a:link, a:visited {


### PR DESCRIPTION
Revert buttons to her old size and split all double button's into two rows.
<img width="371" alt="image" src="https://user-images.githubusercontent.com/165599/107997837-1a55f680-6fe4-11eb-939c-a4d87b250882.png">
<img width="373" alt="image" src="https://user-images.githubusercontent.com/165599/107997917-41142d00-6fe4-11eb-8cca-b6001b7820e7.png">
(iPhone 8 size)