### PR TITLE
remove support for valve type Shower Head and Water Faucet

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -273,8 +273,6 @@
         <select id="valve_type">
           <option id="valve_type_0" value="0">Generic Valve</option>
           <option id="valve_type_1" value="1">Irrigation</option>
-          <option id="valve_type_2" value="2">Shower Head</option>
-          <option id="valve_type_3" value="3">Water Faucet</option>
         </select>
       </div>
       <div class="form-control" id="in_mode_container">

--- a/mos.yml
+++ b/mos.yml
@@ -45,7 +45,7 @@ config_schema:
   - ["sw.in_inverted", "b", false, {title: "Invert input, set to true for normally closed input"}]
   - ["sw.state", "b", false, {title: "State of the switch"}]
   - ["sw.svc_type", "i", 0, {title: "HAP service type, -1 = disable, 0 = switch, 1 = outlet, 2 = lock, 3 = valve"}]
-  - ["sw.valve_type", "i", 1, {title: "HAP valve type (if svc is 3), -1 = disable, 0 = GenericValve, 1 = Irrigation, 2 = ShowerHead, 3 = WaterFaucet"}]
+  - ["sw.valve_type", "i", 1, {title: "HAP valve type (if svc is 3), -1 = disable, 0 = GenericValve, 1 = Irrigation"}] # see for details about non supported types https://github.com/mongoose-os-apps/shelly-homekit/issues/510
   - ["sw.initial_state", "i", 3, {title: "Initial state on power-on: 0 - off, 1 - on, 2 - restore last state, 3 - matches input if in toggle mode, otherwise off"}]
   - ["sw.auto_off", "b", false, {title: "Whether the switch should automatically turn OFF after turning ON"}]
   - ["sw.auto_off_delay", "d", 0, {title: "Delay for automatically turning OFF, in seconds"}]

--- a/src/shelly_hap_valve.cpp
+++ b/src/shelly_hap_valve.cpp
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+ /*
+  * At the moment only GenericValve and Irrigation are supported.
+  * See https://github.com/mongoose-os-apps/shelly-homekit/issues/510 for details.
+  */
+
 #include "shelly_hap_valve.hpp"
 
 #include "mgos_hap_accessory.hpp"

--- a/src/shelly_switch.cpp
+++ b/src/shelly_switch.cpp
@@ -107,7 +107,7 @@ Status ShellySwitch::SetConfig(const std::string &config_json,
   }
   if ((cfg.svc_type != 3 && cfg.valve_type != -1) ||
       (cfg.svc_type == 3 && cfg.valve_type < 0) ||
-      (cfg.svc_type == 3 && cfg.valve_type > 3)) {
+      (cfg.svc_type == 3 && cfg.valve_type > 1)) {
     return mgos::Errorf(STATUS_INVALID_ARGUMENT, "invalid %s", "valve_type");
   }
   if (cfg.in_mode != -2 &&


### PR DESCRIPTION
closes #510, I can't find the problem, so I provide a fix which removes the support for valve type Shower Head and Water Faucet. Generic Valve and Irrigation will still work.

If no one can fix #510, we can remove the support of the non working types to unblock v2.8.0.