### PR TITLE
improve log access in local dev mode and always show debug link

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -147,9 +147,9 @@
         <label>Temperature:</label>
         <span id="sys_temp"></span>&deg;C
       </div>
-      <div class="form-control" id="debug_log_container" style="display: none">
+      <div class="form-control">
         <label>Debug Log:</label>
-        <a href="/debug/log?follow=1">Log</a>
+        <a target="_blank" id="debug_link">Log</a>
       </div>
       <div class="button-container">
         <button class="btn" id="reboot_btn">

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -761,7 +761,6 @@ function getInfo() {
 
       el("homekit_container").style.display = "block";
       el("gs_container").style.display = "block";
-      el("debug_log_container").style.display = "block";
     }).catch(function (err) {
       alert(err);
       console.log(err);
@@ -781,17 +780,25 @@ function setCookie(key, value) {
   document.cookie = `${key}=${JSON.stringify(value)}`;
 }
 
-var host = (new URLSearchParams(location.search)).get("host") || location.host;
+var host = null;
 var socket = null;
 var connectionTries = 0;
 
-function connectWebSocket() {
+function setupHost() {
+  host = (new URLSearchParams(location.search)).get("host") || location.host;
+
   if (!host) {
     host = prompt("Please enter the host of your shelly.");
     if (host !== null) {
       location.href = `${location.host}?host=${host}`;
     }
   }
+
+  el("debug_link").href = `http://${host}/debug/log?follow=1`;
+}
+
+function connectWebSocket() {
+  setupHost();
 
   return new Promise(function (resolve, reject) {
     socket = new WebSocket(`ws://${host}/rpc`);


### PR DESCRIPTION
Changes:
1. With this PR the debug link also works in the local frontend dev mode.
2. I see no longer a need to hide the debug link on load as it's always shown after load.