### PR TITLE
[tech preview] reimplement UI with preact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,10 @@ ShellyU: PLATFORM=ubuntu
 ShellyU: build-ShellyU
 	@true
 
-fs/index.html.gz: fs_src/index.html fs_src/style.css fs_src/script.js fs_src/logo.svg
+fs/index.html.gz: fs_src/index.html fs_src/style.css fs_src/logo.svg
 	cat fs_src/index.html | \
 	sed "s/.*<link.*rel=\"stylesheet\".*/<style>\n\n<\/style>/g" | \
 	sed -e '/<style>/ r fs_src/style.css'  | \
-	sed "s/.*<script.*src=\"script.js\".*/<script>\n\n<\/script>/g"  | \
-	sed -e '/<script>/ r fs_src/script.js' | \
 	sed 's/.*<img.*src="logo.svg".*/<!-- svg -->/g'  | \
 	sed -e '/<!-- svg -->/ r fs_src/logo.svg' | \
 	gzip -9 -c > fs/index.html.gz

--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -6,590 +6,546 @@
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
   <!--  style.css inserted below during build -->
   <link rel="stylesheet" href="style.css">
-</head>
-<body onLoad="onLoad()">
+  <script type="module">
+    // JS code will be extracted back to script.js if work is done
 
-<div class="container" id="header_container">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/" target="_blank">?</a>
-  <!-- logo.svg inserted below during build -->
-  <img id="logo" src="./logo.svg">
-  <h1 class="title">Shelly-<b>HomeKit</b></h1>
-  <div id="badges_container">
-    <a class="badge" id="notify_disconnected" style="display: none">Disconnected</a>
-    <a class="badge" id="notify_update" style="display: none" href="#update_container">Update</a>
-    <a class="badge" id="notify_overheat" style="display: none">Overheating</a>
-    <a class="badge" id="notify_failsafe" style="display: none">Failsafe mode</a>
-  </div>
-  <h1 class="" id="device_name">Loading ...</h1>
-</div>
+    // DEV MODE
+    // import * as htm_preact_standalone from 'https://unpkg.com/htm/preact/standalone.module.js';
 
-<div class="container" id="gs_container" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/General-Settings"
-     target="_blank">?</a>
-  <h1 class="">General Settings</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Name:</label>
-        <input type="text" id="sys_name">
-      </div>
-      <div class="form-control" id="sys_mode_container" style="display: none">
-        <label>Mode:</label>
-        <select id="sys_mode">
-          <option id="sys_mode_0" value="0">Switch</option>
-          <option id="sys_mode_1" value="1">Roller Shutter</option>
-          <option id="sys_mode_2" value="2">Garage Door Opener</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="sys_save_btn">
-          <label><span id="sys_save_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-<div id="components"></div>
-<div class="container" id="homekit_container" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/HomeKit-settings"
-     target="_blank">?</a>
-  <h1 class="">HomeKit Settings</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Paired:</label>
-        <span id="hap_paired"></span>
-      </div>
-      <div class="form-control">
-        <label>Connections:</label>
-        <ul id="hap_conn_stats" class="comma-list">
-          <li id="hap_ip_conns_pending"></li>
-          <li id="hap_ip_conns_active"></li>
-          <li id="hap_ip_conns_max"></li>
-        </ul>
-      </div>
-      <div class="form-control">
-        <label>Setup code:</label>
-        <input type="text" id="hap_setup_code" placeholder="111-22-333">
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="hap_save_btn">
-          <label><span id="hap_save_spinner"></span>Save</label>
-        </button>
-        <button class="btn" id="hap_reset_btn">
-          <label><span id="hap_reset_spinner"></span>Reset</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="container" id="wifi_container" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/WiFi-Settings"
-     target="_blank">?</a>
-  <h1 class="">WiFi Settings</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Enable:</label>
-        <label class="switch">
-          <input type="checkbox" id="wifi_en">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label>WiFi network:</label>
-        <input type="text" id="wifi_ssid">
-      </div>
-      <div class="form-control">
-        <label>WiFi password:</label>
-        <input type="password" id="wifi_pass">
-      </div>
-      <div class="form-control" id="wifi_rssi_container">
-        <label>RSSI:</label>
-        <span id="wifi_rssi"></span>
-      </div>
-      <div class="form-control" id="host_container">
-        <label>Host:</label>
-        <span id="host"></span>
-      </div>
-      <div class="form-control" id="wifi_ip_container">
-        <label>IP:</label>
-        <span id="wifi_ip"></span>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="wifi_save_btn">
-          <label><span id="wifi_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+    // BUILD MODE standalone.module.js, inlined by make script
+    var e,n,t,_,o,r,u,l={},i=[],c=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i;function s(e,n){for(var t in n)e[t]=n[t];return e}function f(e){var n=e.parentNode;n&&n.removeChild(e)}function a(e,n,t){var _,o=arguments,r={};for(_ in n)"key"!==_&&"ref"!==_&&(r[_]=n[_]);if(arguments.length>3)for(t=[t],_=3;_<arguments.length;_++)t.push(o[_]);if(null!=t&&(r.children=t),"function"==typeof e&&null!=e.defaultProps)for(_ in e.defaultProps)void 0===r[_]&&(r[_]=e.defaultProps[_]);return p(e,r,n&&n.key,n&&n.ref,null)}function p(n,t,_,o,r){var u={type:n,props:t,key:_,ref:o,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,constructor:void 0,__v:r};return null==r&&(u.__v=u),e.vnode&&e.vnode(u),u}function h(e){return e.children}function d(e,n){this.props=e,this.context=n}function v(e,n){if(null==n)return e.__?v(e.__,e.__.__k.indexOf(e)+1):null;for(var t;n<e.__k.length;n++)if(null!=(t=e.__k[n])&&null!=t.__e)return t.__e;return"function"==typeof e.type?v(e):null}function m(e){var n,t;if(null!=(e=e.__)&&null!=e.__c){for(e.__e=e.__c.base=null,n=0;n<e.__k.length;n++)if(null!=(t=e.__k[n])&&null!=t.__e){e.__e=e.__c.base=t.__e;break}return m(e)}}function y(r){(!r.__d&&(r.__d=!0)&&n.push(r)&&!t++||o!==e.debounceRendering)&&((o=e.debounceRendering)||_)(g)}function g(){for(var e;t=n.length;)e=n.sort(function(e,n){return e.__v.__b-n.__v.__b}),n=[],e.some(function(e){var n,t,_,o,r,u,l;e.__d&&(u=(r=(n=e).__v).__e,(l=n.__P)&&(t=[],(_=s({},r)).__v=_,o=H(l,r,_,n.__n,void 0!==l.ownerSVGElement,null,t,null==u?v(r):u),S(t,r),o!=u&&m(r)))})}function k(e,n,t,_,o,r,u,c,s){var a,p,h,d,m,y,g,k=t&&t.__k||i,x=k.length;if(c==l&&(c=null!=r?r[0]:x?v(t,0):null),a=0,n.__k=b(n.__k,function(t){if(null!=t){if(t.__=n,t.__b=n.__b+1,null===(h=k[a])||h&&t.key==h.key&&t.type===h.type)k[a]=void 0;else for(p=0;p<x;p++){if((h=k[p])&&t.key==h.key&&t.type===h.type){k[p]=void 0;break}h=null}if(d=H(e,t,h=h||l,_,o,r,u,c,s),(p=t.ref)&&h.ref!=p&&(g||(g=[]),h.ref&&g.push(h.ref,null,t),g.push(p,t.__c||d,t)),null!=d){var i;if(null==y&&(y=d),void 0!==t.__d)i=t.__d,t.__d=void 0;else if(r==h||d!=c||null==d.parentNode){e:if(null==c||c.parentNode!==e)e.appendChild(d),i=null;else{for(m=c,p=0;(m=m.nextSibling)&&p<x;p+=2)if(m==d)break e;e.insertBefore(d,c),i=c}"option"==n.type&&(e.value="")}c=void 0!==i?i:d.nextSibling,"function"==typeof n.type&&(n.__d=c)}else c&&h.__e==c&&c.parentNode!=e&&(c=v(h))}return a++,t}),n.__e=y,null!=r&&"function"!=typeof n.type)for(a=r.length;a--;)null!=r[a]&&f(r[a]);for(a=x;a--;)null!=k[a]&&D(k[a],k[a]);if(g)for(a=0;a<g.length;a++)P(g[a],g[++a],g[++a])}function b(e,n,t){if(null==t&&(t=[]),null==e||"boolean"==typeof e)n&&t.push(n(null));else if(Array.isArray(e))for(var _=0;_<e.length;_++)b(e[_],n,t);else t.push(n?n("string"==typeof e||"number"==typeof e?p(null,e,null,null,e):null!=e.__e||null!=e.__c?p(e.type,e.props,e.key,null,e.__v):e):e);return t}function x(e,n,t){"-"===n[0]?e.setProperty(n,t):e[n]="number"==typeof t&&!1===c.test(n)?t+"px":null==t?"":t}function w(e,n,t,_,o){var r,u,l,i,c;if(o?"className"===n&&(n="class"):"class"===n&&(n="className"),"style"===n)if(r=e.style,"string"==typeof t)r.cssText=t;else{if("string"==typeof _&&(r.cssText="",_=null),_)for(i in _)t&&i in t||x(r,i,"");if(t)for(c in t)_&&t[c]===_[c]||x(r,c,t[c])}else"o"===n[0]&&"n"===n[1]?(u=n!==(n=n.replace(/Capture$/,"")),l=n.toLowerCase(),n=(l in e?l:n).slice(2),t?(_||e.addEventListener(n,C,u),(e.l||(e.l={}))[n]=t):e.removeEventListener(n,C,u)):"list"!==n&&"tagName"!==n&&"form"!==n&&"type"!==n&&"size"!==n&&!o&&n in e?e[n]=null==t?"":t:"function"!=typeof t&&"dangerouslySetInnerHTML"!==n&&(n!==(n=n.replace(/^xlink:?/,""))?null==t||!1===t?e.removeAttributeNS("http://www.w3.org/1999/xlink",n.toLowerCase()):e.setAttributeNS("http://www.w3.org/1999/xlink",n.toLowerCase(),t):null==t||!1===t&&!/^ar/.test(n)?e.removeAttribute(n):e.setAttribute(n,t))}function C(n){this.l[n.type](e.event?e.event(n):n)}function H(n,t,_,o,r,u,l,i,c){var f,a,p,v,m,y,g,b,x,w,C=t.type;if(void 0!==t.constructor)return null;(f=e.__b)&&f(t);try{e:if("function"==typeof C){if(b=t.props,x=(f=C.contextType)&&o[f.__c],w=f?x?x.props.value:f.__:o,_.__c?g=(a=t.__c=_.__c).__=a.__E:("prototype"in C&&C.prototype.render?t.__c=a=new C(b,w):(t.__c=a=new d(b,w),a.constructor=C,a.render=N),x&&x.sub(a),a.props=b,a.state||(a.state={}),a.context=w,a.__n=o,p=a.__d=!0,a.__h=[]),null==a.__s&&(a.__s=a.state),null!=C.getDerivedStateFromProps&&(a.__s==a.state&&(a.__s=s({},a.__s)),s(a.__s,C.getDerivedStateFromProps(b,a.__s))),v=a.props,m=a.state,p)null==C.getDerivedStateFromProps&&null!=a.componentWillMount&&a.componentWillMount(),null!=a.componentDidMount&&a.__h.push(a.componentDidMount);else{if(null==C.getDerivedStateFromProps&&b!==v&&null!=a.componentWillReceiveProps&&a.componentWillReceiveProps(b,w),!a.__e&&null!=a.shouldComponentUpdate&&!1===a.shouldComponentUpdate(b,a.__s,w)||t.__v===_.__v&&!a.__){for(a.props=b,a.state=a.__s,t.__v!==_.__v&&(a.__d=!1),a.__v=t,t.__e=_.__e,t.__k=_.__k,a.__h.length&&l.push(a),f=0;f<t.__k.length;f++)t.__k[f]&&(t.__k[f].__=t);break e}null!=a.componentWillUpdate&&a.componentWillUpdate(b,a.__s,w),null!=a.componentDidUpdate&&a.__h.push(function(){a.componentDidUpdate(v,m,y)})}a.context=w,a.props=b,a.state=a.__s,(f=e.__r)&&f(t),a.__d=!1,a.__v=t,a.__P=n,f=a.render(a.props,a.state,a.context),t.__k=null!=f&&f.type==h&&null==f.key?f.props.children:Array.isArray(f)?f:[f],null!=a.getChildContext&&(o=s(s({},o),a.getChildContext())),p||null==a.getSnapshotBeforeUpdate||(y=a.getSnapshotBeforeUpdate(v,m)),k(n,t,_,o,r,u,l,i,c),a.base=t.__e,a.__h.length&&l.push(a),g&&(a.__E=a.__=null),a.__e=!1}else null==u&&t.__v===_.__v?(t.__k=_.__k,t.__e=_.__e):t.__e=E(_.__e,t,_,o,r,u,l,c);(f=e.diffed)&&f(t)}catch(n){t.__v=null,e.__e(n,t,_)}return t.__e}function S(n,t){e.__c&&e.__c(t,n),n.some(function(t){try{n=t.__h,t.__h=[],n.some(function(e){e.call(t)})}catch(n){e.__e(n,t.__v)}})}function E(e,n,t,_,o,r,u,c){var s,f,a,p,h,d=t.props,v=n.props;if(o="svg"===n.type||o,null!=r)for(s=0;s<r.length;s++)if(null!=(f=r[s])&&((null===n.type?3===f.nodeType:f.localName===n.type)||e==f)){e=f,r[s]=null;break}if(null==e){if(null===n.type)return document.createTextNode(v);e=o?document.createElementNS("http://www.w3.org/2000/svg",n.type):document.createElement(n.type,v.is&&{is:v.is}),r=null,c=!1}if(null===n.type)d!==v&&e.data!=v&&(e.data=v);else{if(null!=r&&(r=i.slice.call(e.childNodes)),a=(d=t.props||l).dangerouslySetInnerHTML,p=v.dangerouslySetInnerHTML,!c){if(d===l)for(d={},h=0;h<e.attributes.length;h++)d[e.attributes[h].name]=e.attributes[h].value;(p||a)&&(p&&a&&p.__html==a.__html||(e.innerHTML=p&&p.__html||""))}(function(e,n,t,_,o){var r;for(r in t)"children"===r||"key"===r||r in n||w(e,r,null,t[r],_);for(r in n)o&&"function"!=typeof n[r]||"children"===r||"key"===r||"value"===r||"checked"===r||t[r]===n[r]||w(e,r,n[r],t[r],_)})(e,v,d,o,c),n.__k=n.props.children,p||k(e,n,t,_,"foreignObject"!==n.type&&o,r,u,l,c),c||("value"in v&&void 0!==v.value&&v.value!==e.value&&(e.value=null==v.value?"":v.value),"checked"in v&&void 0!==v.checked&&v.checked!==e.checked&&(e.checked=v.checked))}return e}function P(n,t,_){try{"function"==typeof n?n(t):n.current=t}catch(n){e.__e(n,_)}}function D(n,t,_){var o,r,u;if(e.unmount&&e.unmount(n),(o=n.ref)&&(o.current&&o.current!==n.__e||P(o,null,t)),_||"function"==typeof n.type||(_=null!=(r=n.__e)),n.__e=n.__d=void 0,null!=(o=n.__c)){if(o.componentWillUnmount)try{o.componentWillUnmount()}catch(n){e.__e(n,t)}o.base=o.__P=null}if(o=n.__k)for(u=0;u<o.length;u++)o[u]&&D(o[u],t,_);null!=r&&f(r)}function N(e,n,t){return this.constructor(e,t)}function T(n,t,_){var o,u,c;e.__&&e.__(n,t),u=(o=_===r)?null:_&&_.__k||t.__k,n=a(h,null,[n]),c=[],H(t,(o?t:_||t).__k=n,u||l,l,void 0!==t.ownerSVGElement,_&&!o?[_]:u?null:i.slice.call(t.childNodes),c,_||l,o),S(c,n)}function U(e){var n={},t={__c:"__cC"+u++,__:e,Consumer:function(e,n){return e.children(n)},Provider:function(e){var _,o=this;return this.getChildContext||(_=[],this.getChildContext=function(){return n[t.__c]=o,n},this.shouldComponentUpdate=function(e){o.props.value!==e.value&&_.some(function(n){n.context=e.value,y(n)})},this.sub=function(e){_.push(e);var n=e.componentWillUnmount;e.componentWillUnmount=function(){_.splice(_.indexOf(e),1),n&&n.call(e)}}),e.children}};return t.Consumer.contextType=t,t}e={__e:function(e,n){for(var t,_;n=n.__;)if((t=n.__c)&&!t.__)try{if(t.constructor&&null!=t.constructor.getDerivedStateFromError&&(_=!0,t.setState(t.constructor.getDerivedStateFromError(e))),null!=t.componentDidCatch&&(_=!0,t.componentDidCatch(e)),_)return y(t.__E=t)}catch(n){e=n}throw e}},d.prototype.setState=function(e,n){var t;t=this.__s!==this.state?this.__s:this.__s=s({},this.state),"function"==typeof e&&(e=e(t,this.props)),e&&s(t,e),null!=e&&this.__v&&(n&&this.__h.push(n),y(this))},d.prototype.forceUpdate=function(e){this.__v&&(this.__e=!0,e&&this.__h.push(e),y(this))},d.prototype.render=h,n=[],t=0,_="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,r=l,u=0;var A,M,F,L=[],W=e.__r,R=e.diffed,V=e.__c,I=e.unmount;function O(n){e.__h&&e.__h(M);var t=M.__H||(M.__H={__:[],__h:[]});return n>=t.__.length&&t.__.push({}),t.__[n]}function q(e){return B(te,e)}function B(e,n,t){var _=O(A++);return _.__c||(_.__c=M,_.__=[t?t(n):te(void 0,n),function(n){var t=e(_.__[0],n);_.__[0]!==t&&(_.__[0]=t,_.__c.setState({}))}]),_.__}function $(e,n){var t=O(A++);ne(t.__H,n)&&(t.__=e,t.__H=n,M.__H.__h.push(t))}function j(e,n){var t=O(A++);ne(t.__H,n)&&(t.__=e,t.__H=n,M.__h.push(t))}function z(e){return J(function(){return{current:e}},[])}function G(e,n,t){j(function(){"function"==typeof e?e(n()):e&&(e.current=n())},null==t?t:t.concat(e))}function J(e,n){var t=O(A++);return ne(t.__H,n)?(t.__H=n,t.__h=e,t.__=e()):t.__}function K(e,n){return J(function(){return e},n)}function Q(e){var n=M.context[e.__c];if(!n)return e.__;var t=O(A++);return null==t.__&&(t.__=!0,n.sub(M)),n.props.value}function X(n,t){e.useDebugValue&&e.useDebugValue(t?t(n):n)}function Y(){L.some(function(n){if(n.__P)try{n.__H.__h.forEach(Z),n.__H.__h.forEach(ee),n.__H.__h=[]}catch(t){return n.__H.__h=[],e.__e(t,n.__v),!0}}),L=[]}function Z(e){e.t&&e.t()}function ee(e){var n=e.__();"function"==typeof n&&(e.t=n)}function ne(e,n){return!e||n.some(function(n,t){return n!==e[t]})}function te(e,n){return"function"==typeof n?n(e):n}e.__r=function(e){W&&W(e),A=0,(M=e.__c).__H&&(M.__H.__h.forEach(Z),M.__H.__h.forEach(ee),M.__H.__h=[])},e.diffed=function(n){R&&R(n);var t=n.__c;if(t){var _=t.__H;_&&_.__h.length&&(1!==L.push(t)&&F===e.requestAnimationFrame||((F=e.requestAnimationFrame)||function(e){var n,t=function(){clearTimeout(_),cancelAnimationFrame(n),setTimeout(e)},_=setTimeout(t,100);"undefined"!=typeof window&&(n=requestAnimationFrame(t))})(Y))}},e.__c=function(n,t){t.some(function(n){try{n.__h.forEach(Z),n.__h=n.__h.filter(function(e){return!e.__||ee(e)})}catch(_){t.some(function(e){e.__h&&(e.__h=[])}),t=[],e.__e(_,n.__v)}}),V&&V(n,t)},e.unmount=function(n){I&&I(n);var t=n.__c;if(t){var _=t.__H;if(_)try{_.__.forEach(function(e){return e.t&&e.t()})}catch(n){e.__e(n,t.__v)}}};var _e=function(e,n,t,_){var o;n[0]=0;for(var r=1;r<n.length;r++){var u=n[r++],l=n[r]?(n[0]|=u?1:2,t[n[r++]]):n[++r];3===u?_[0]=l:4===u?_[1]=Object.assign(_[1]||{},l):5===u?(_[1]=_[1]||{})[n[++r]]=l:6===u?_[1][n[++r]]+=l+"":u?(o=e.apply(l,_e(e,l,t,["",null])),_.push(o),l[0]?n[0]|=2:(n[r-2]=0,n[r]=o)):_.push(l)}return _},oe=new Map,re=function(e){var n=oe.get(this);return n||(n=new Map,oe.set(this,n)),(n=_e(this,n.get(e)||(n.set(e,n=function(e){for(var n,t,_=1,o="",r="",u=[0],l=function(e){1===_&&(e||(o=o.replace(/^\s*\n\s*|\s*\n\s*$/g,"")))?u.push(0,e,o):3===_&&(e||o)?(u.push(3,e,o),_=2):2===_&&"..."===o&&e?u.push(4,e,0):2===_&&o&&!e?u.push(5,0,!0,o):_>=5&&((o||!e&&5===_)&&(u.push(_,0,o,t),_=6),e&&(u.push(_,e,0,t),_=6)),o=""},i=0;i<e.length;i++){i&&(1===_&&l(),l(i));for(var c=0;c<e[i].length;c++)n=e[i][c],1===_?"<"===n?(l(),u=[u],_=3):o+=n:4===_?"--"===o&&">"===n?(_=1,o=""):o=n+o[0]:r?n===r?r="":o+=n:'"'===n||"'"===n?r=n:">"===n?(l(),_=1):_&&("="===n?(_=5,t=o,o=""):"/"===n&&(_<5||">"===e[i][c+1])?(l(),3===_&&(u=u[0]),_=u,(u=u[0]).push(2,0,_),_=0):" "===n||"\t"===n||"\n"===n||"\r"===n?(l(),_=2):o+=n),3===_&&"!--"===o&&(_=4,u=u[0])}return l(),u}(e)),n),arguments,[])).length>1?n:n[0]}.bind(a);
+    const htm_preact_standalone = {h: a,html: re,render: T,Component: d,createContext: U,useState: q,useReducer: B,useEffect: $,useLayoutEffect: j,useRef: z,useImperativeHandle: G,useMemo: J,useCallback: K,useContext: Q,useDebugValue: X};
+    // BUILD MODE END
 
-<div class="container" id="sys_container" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/System-Settings"
-     target="_blank">?</a>
-  <h1 class="">System</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Model:</label>
-        <span id="model"></span>
-      </div>
-      <div class="form-control">
-        <label>Device Id:</label>
-        <span id="device_id"></span>
-      </div>
-      <div class="form-control">
-        <label>Uptime:</label>
-        <span id="uptime"></span>
-      </div>
-      <div class="form-control" id="sys_temp_container" style="display: none">
-        <label>Temperature:</label>
-        <span id="sys_temp"></span>&deg;C
-      </div>
-      <div class="form-control" id="debug_log_container" style="display: none">
-        <label>Debug Log:</label>
-        <label class="switch">
-          <input type="checkbox" id="debug_en">
-          <span class="slider round"></span>
-        </label>
-        <span id="debug_link"><a href="/debug/log?follow=1" style="margin-left: 1em">Log</a></span>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="reboot_btn">
-          <label>Reboot</label>
-        </button>
-        <button class="btn" id="reset_btn">
-          <label>Reset</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+    const { html, Component, render, useEffect, useState } = htm_preact_standalone;
 
-<div class="container" id="firmware_container" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Firmware"
-     target="_blank">?</a>
-  <h1 class="">Firmware</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Version:</label>
-        <span id="version"></span>
-      </div>
-      <div class="form-control">
-        <label>Build:</label>
-        <span id="fw_build1"></span>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <span id="fw_build2"></span>
-      </div>
-      <div class="form-control" id="update_container" style="display: none">
-        <label>Update: </label>
-        <button class="btn" id="update_btn">
-          <label>
-            <span id="update_btn_spinner"></span>
-            <span id="update_btn_text">Check</span>
+    const repoUrl = "https://github.com/mongoose-os-apps/shelly-homekit";
+
+    // part of preact/compat
+    function createRef() {
+      return { current: null };
+    }
+
+    class App extends Component {
+      constructor() {
+        super();
+        this.state = { remoteHost: App.host() };
+
+        apiClient.bind(this);
+        if (this.state.remoteHost !== null) apiClient.connect(this.state.remoteHost);
+      }
+
+      componentDidCatch(e) {
+        console.log(e)
+      }
+
+      static host() {
+        if(location.host !== "") return location.host;
+        return location.host || (new URLSearchParams(location.search)).get("host")
+      }
+
+      render(props, {loaded, remoteHost, ...state}) {
+        if(!remoteHost) return html`<${DevConnect} ...${state}/>`;
+
+        return html`
+          <${Header} ...${state}/>
+          ${loaded && html`
+            <${GeneralSettings} ...${state}/>
+            <${DeviceComponents} ...${state}/>
+            <${HomeKit} ...${state}/>
+            <${Wifi} ...${state}/>
+            <${System} ...${state}/>
+            <${Firmware} ...${state}/>
+          `}
+          <${Footer} ...${state}/>
+        `;
+      }
+    }
+
+    function Header({name, connected, update, overheat_on, failsafe_mode}) {
+      const badge = ({show, label}) => {
+        return show && html`<a class="badge">${label}</a>`;
+      }
+
+      return html`
+        <${Container} helpurl="/" headline="${name || "Loading..."}">
+          <img id="logo" src="./logo.svg"/>
+          <h1 class="title">Shelly-<b>HomeKit</b></h1>
+          <div id="badges_container">
+            <${badge} show="${!connected}" label="Disconnected"/>
+            <${badge} show="${update}" label="Update"/>
+            <${badge} show="${overheat_on}" label="Overheating"/>
+            <${badge} show="${failsafe_mode}" label="Failsafe mode"/>
+          </div>
+        <//>
+      `;
+    }
+
+    function GeneralSettings({name, sys_mode, rsh_avail, gdo_avail}) { // TODO rsh_avail -> wc_avail
+      const { getFormData, bindInput, bindSelect, bindButton } = useForm({name, sys_mode});
+
+      const modes = { 0: "Switch" };
+      if(rsh_avail) modes[1] = "Roller Shutter";
+      if(gdo_avail) modes[2] = "Garage Door Opener";
+
+      const save = (completeHandler) => {
+        apiClient.setConfig(getFormData(), completeHandler);
+      }
+
+      return html`
+        <${Container} headline="General-Settings" helpurl="/General-Settings">
+          <${InputBlock} label="Name" ...${bindInput('name')} />
+          ${(rsh_avail || gdo_avail) && html`
+            <${SelectBlock} label="Mode" options="${modes}" ...${bindSelect('sys_mode')}/>
+          `}
+          <${ButtonBlock} label="Save" ...${bindButton(save)}/>
+        <//>
+      `;
+    }
+
+    function DeviceComponents({components}) {
+      return components.map(DummyComponent);
+    }
+
+    function DummyComponent({id, type, name, ...rest}) {
+      const typeName = (type) => {
+        switch(type){
+          case 0: return "Switch";
+          case 1: return "Outlet";
+          case 2: return "Lock";
+          case 3: return "Stateless Programmable Switch";
+          case 4: return "Window Covering";
+          case 5: return "Garage Door Opener";
+          case 6: return "Disabled Input";
+          case 7: return "Motion Sensor";
+          case 8: return "Occupancy Sensor";
+          case 9: return "Contact Sensor";
+          default: return `Unkown ${type}`;
+        }
+      }
+
+      const format = (value) => {
+        switch(typeof value) {
+          case 'boolean':
+            return Helper.yesNo(value);
+          default:
+            return value;
+        }
+      }
+
+      return html`
+        <${Container} headline="${typeName(type)} ${id} (${name})">
+          <span>TODO: Component support</span>
+          ${Object.entries(rest).map(([label, info]) => html`
+            <${InfoBlock} label="${label}" info="${format(info)}"/>
+          `)}
+        <//>
+      `;
+    }
+
+    function HomeKit({hap_cn, hap_running, hap_paired, hap_ip_conns_pending, hap_ip_conns_active, hap_ip_conns_max}) {
+      const { getFormData, bindInput, bindButton } = useForm({code: (hap_running ? "***-**-***" : "")});
+
+      const save = (completeHandler) => {
+        var { code } = getFormData();
+        var codeMatch = code.match(/^(\d{3})\-?(\d{2})\-?(\d{3})$/);
+
+        if (!codeMatch) {
+          alert(`Invalid code ${code}, must be xxxyyzzz or xxx-yy-zzz.`);
+          completeHandler();
+          return;
+        }
+
+        apiClient.send("HAP.Setup", {
+          code: codeMatch.slice(1).join('-')
+        }, completeHandler);
+      }
+
+      const reset = (completeHandler) => {
+        if(!confirm("HAP reset will erase all pairings and clear setup code. Are you sure?")) return;
+        apiClient.send("HAP.Reset", { reset_server: true, reset_code: true }, completeHandler);
+      }
+
+      return html`
+        <${Container} headline="HomeKit Settings" helpurl="/HomeKit-settings">
+          <${InfoBlock} label="Paired" info="${Helper.yesNo(hap_paired)}"/>
+          <${InfoBlock} label="Connections" info="${hap_ip_conns_pending} pending, ${hap_ip_conns_active} active, ${hap_ip_conns_max} max"/>
+          <${InputBlock} label="Setup code" placeholder="111-22-333" ...${bindInput('code')})}/>
+          <${FormBlock}>
+            <${Button} label="Save" ...${bindButton(save)}/>
+            <${Button} label="Reset" ...${bindButton(reset)}/>
+          <//>
+        <//>
+      `;
+    }
+
+    function Wifi({wifi_en, wifi_ssid, wifi_pass, wifi_rssi, wifi_ip, host}) {
+      const { getFormData, bindInput, bindSwitch, bindButton } = useForm({wifi_en, wifi_ssid, wifi_pass});
+
+      const save = (completeHandler) => {
+        const { wifi_en: enable, wifi_ssid: ssid, wifi_pass: pass } = getFormData();
+
+        if(enable && pass == '***') {
+          alert('Wifi password is invalid!');
+          completeHandler();
+          return;
+        }
+
+        apiClient.setConfig({
+          wifi: {
+            sta: { enable, ssid, pass },
+            ap: { enable: !enable }
+          }
+        }, completeHandler);
+      }
+
+      return html`
+        <${Container} headline="WiFi Settings" helpurl="/WiFi-Settings">
+          <${SwitchBlock} label="Enabled" ...${bindSwitch('wifi_en')}/>
+          <${InputBlock} label="Network" ...${bindInput('wifi_ssid')}/>
+          <${InputBlock} label="Password" ...${bindInput('wifi_pass')}/>
+          <${InfoBlock} label="RSSI" info="${wifi_rssi}"/>
+          <${InfoBlock} label="Host" info="${host}"/>
+          <${InfoBlock} label="IP" info="${wifi_ip}"/>
+          <${ButtonBlock} label="Save" ...${bindButton(save)}/>
+        <//>
+      `;
+    }
+
+    function System({model, device_id, uptime, sys_temp, debug_en}) {
+      const { bindButton, bindSwitch } = useForm({debug_en});
+
+      const toggleDebug = (completeHandler) => {
+        apiClient.setConfig({debug_en: !debug_en}, () => {
+          apiClient.getInfo();
+          completeHandler();
+        })
+      }
+
+      const reboot = (completeHandler) => {
+        if(!confirm("Reboot the device?")) return completeHandler();
+        apiClient.send("Sys.Reboot", { delay_ms: 500 });
+      }
+
+      const reset = () => {
+        if(!confirm("Device configuration will be wiped and return to AP mode. Are you sure?")) return completeHandler();
+        apiClient.send("Shelly.WipeDevice");
+      }
+
+      return html`
+        <${Container} headline="System" helpurl="/System-Settings">
+          <${InfoBlock} label="Model" info="${model}"/>
+          <${InfoBlock} label="Device Id" info="${device_id}"/>
+          <${InfoBlock} label="Uptime" info="${Helper.durationStr(uptime)}"/>
+          ${sys_temp && html`
+            <!-- TODO fix &deg; -->
+            <${InfoBlock} label="Temperature" info="${sys_temp}°C"/>
+          `}
+          <${SwitchBlock} label="Debug Log" ...${bindSwitch('debug_en', toggleDebug)}>
+            ${debug_en && html`
+              <a href="/debug/log?follow=1" style="margin-left: 1em">Log</a>
+            `}
+          <//>
+          <${FormBlock}>
+            <${Button} label="Reboot" ...${bindButton(reboot)}/>
+            <${Button} label="Reset" ...${bindButton(reset)}/>
+          <//>
+        <//>
+      `;
+    }
+
+    function Firmware({version, fw_build}) {
+      const { bindButton } = useForm();
+
+      const demo = (completeHandler) => {
+        alert("Not implemented yet!");
+        completeHandler();
+      }
+
+      return html`
+        <${Container} headline="Firmware" helpurl="/Firmware">
+          <${InfoBlock} label="Version" info="${version}"/>
+          <${InfoBlock} label="Build" info="${fw_build.split('/')[0]}"/>
+          <${InfoBlock} info="${fw_build.split('/')[1]}"/>
+          <${ButtonBlock} label="Check for update" ...${bindButton(demo)}>
+            TODO
+            <span id="update_status"></span>
+          <//>
+          <${ButtonBlock} label="Revert to stock" ...${bindButton(demo)}>
+            TODO
+            <span id="revert_status"></span>
+            <div id="revert_msg" style="margin-left: 9em; display: none">
+              Please consider reporting missing features
+              <a href="https://github.com/mongoose-os-apps/shelly-homekit/issues">on GitHub</a>.
+            </div>
+          <//>
+          <form method="POST" action="/update" enctype="multipart/form-data">
+            <${InputBlock} label="Update from file" type="file" accept=".zip"/>
+            <${ButtonBlock} label="Upload" ...${bindButton(demo)}/>
+          </form>
+        <//>
+      `;
+    }
+
+    function Footer({wifi_en}) {
+      return html`
+        <div class="container">
+          <div class="form" style="text-align: center">
+            © Copyright 2020 <a href="${repoUrl}/blob/master/AUTHORS.md">Shelly-HomeKit
+            contributors</a>.
+            <br/>Use <a href="${repoUrl}/issues">GitHub</a> to report bugs and
+            request features.
+            <br/>
+            ${wifi_en && html`
+              <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+                <input type="hidden" name="cmd" value="_s-xclick"/>
+                <input type="hidden" name="hosted_button_id" value="6KPSKWJDHVLB4"/>
+                <input type="image" id="donate_form_submit" border="0" name="submit" title="Donate via PayPal"
+                       alt="Donate via PayPal" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"/>
+              </form>
+            `}
+          </div>
+        </div>
+      `;
+    }
+
+    function DevConnect() {
+      const hostField = createRef();
+
+      const connect = () => {
+        location.href = `${location.host}?host=${hostField.current.value}`;
+      }
+
+      return html`
+        <${Container} headline="Development Mode">
+          <${InputBlock} label="Host" pref="${hostField}"/>
+          <${ButtonBlock} label="Connect" onClick="${connect}"/>
+        <//>
+      `;
+    }
+
+    function Container({headline, helpurl, children}) {
+      return html`
+        <div class="container">
+          ${helpurl && html`
+            <a class="helpbadge" href="${repoUrl}/wiki${helpurl}" target="_blank">?</a>
+          `}
+          <h1>${headline}</h1>
+          <div class="form">
+            ${children}
+          </div>
+        </div>
+      `;
+    }
+
+    function FormBlock({label, children}) {
+      return html`
+        <div class="form-control">
+          <label>${label && `${label}:`}</label>
+          ${children}
+        </div>
+      `;
+    }
+
+    function InputBlock({label, value, type = "text", placeholder = null, accept = null, onInput = null, pref = null}) {
+      return html`
+        <${FormBlock} label="${label}">
+          <input type="${type}" value="${value}" placeholder="${placeholder}" accept="${accept}" onInput="${onInput}" ref="${pref}"/>
+        <//>
+      `;
+    }
+
+    function SwitchBlock({label, checked, spin, onClick = null, children}) {
+      return html`
+        <${FormBlock} label="${label}">
+          <label class="switch">
+            <input type="checkbox" checked="${checked}" onClick=${onClick}/>
+            <span class="slider round"></span>
           </label>
+          <div class="spinner_container">
+            <span class="spinner ${spin && 'spin'}"></span>
+          </div>
+          ${children}
+        <//>
+      `;
+    }
+
+    function SelectBlock({label, select, options, onChange}) {
+      return html`
+        <${FormBlock} label="${label}">
+          <select onChange="${onChange}">
+            ${Object.entries(options).map(([value, label]) => html`
+              <option value="${value}" ...${{selected: (select == value)}}>${label}</option>
+            `)}
+          </select>
+        <//>
+      `;
+    }
+
+    function InfoBlock({label, info}) {
+      return html`
+        <${FormBlock} label="${label}">
+          <span>${info}</span>
+        <//>
+      `;
+    }
+
+    function Button({label, spin, onClick}) {
+      return html`
+        <button class="btn" onClick=${onClick}>
+          <label><span class="spinner ${spin && 'spin'}"></span>${label}</label>
         </button>
-        <span id="update_status"></span>
-      </div>
-      <div class="form-control" id="revert_to_stock_container" style="display: none">
-        <label>Revert to stock:</label>
-        <button class="btn" id="revert_btn">
-          <label><span id="revert_btn_spinner"></span>Revert</label>
-        </button>
-        <span id="revert_status"></span>
-        <div id="revert_msg" style="margin-left: 9em; display: none">Please consider reporting missing features
-          <a href="https://github.com/mongoose-os-apps/shelly-homekit/issues">on GitHub</a>.
+      `;
+    }
+
+    function ButtonBlock(props) {
+      return html`
+        <${FormBlock}>
+          <${Button} ...${props}/>
         </div>
-      </div>
-      <form id="fw_upload_form" method="POST" action="/update" enctype="multipart/form-data" style="display: inline">
-        <div class="form-control">
-          <label>Update from file:</label>
-          <input type="file" id="fw_select_file" name="file" accept=".zip" style="width: 200px;">
-        </div>
-        <div class="form-control">
-          <label></label>
-          <button class="btn" id="fw_upload_btn">
-            <label><span id="fw_spinner"></span>Upload</label>
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
+      `;
+    }
 
-<div class="container">
-  <div class="form" style="text-align: center">
-    &copy; Copyright 2020 <a href="https://github.com/mongoose-os-apps/shelly-homekit/blob/master/AUTHORS.md">Shelly-HomeKit
-    contributors</a>.
-    <br>Use <a href="https://github.com/mongoose-os-apps/shelly-homekit/issues">GitHub</a> to report bugs and
-    request features.
-    <br>
-    <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-      <input type="hidden" name="cmd" value="_s-xclick"/>
-      <input type="hidden" name="hosted_button_id" value="6KPSKWJDHVLB4"/>
-      <input type="image" id="donate_form_submit" border="0" name="submit" title="Donate via PayPal"
-             alt="Donate via PayPal" style="display: none"/>
-    </form>
-  </div>
-</div>
+    class ApiClient {
+      requestId = 0
+      callbacks = {}
 
-<!-- Component section templates -->
+      bind(app) {
+        this.app = app;
+      }
 
-<div class="container" id="sw_template" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Switch-Settings"
-     target="_blank">?</a>
-  <h1 id="head">Switch</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control" id="state_container">
-        <label for="state">Status:</label>
-        <label class="switch">
-          <input type="checkbox" id="state">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control" id="power_stats_container" style="display: none;">
-        <label for="power_stats">Power:</label>
-        <span id="power_stats"></span>
-        </label>
-      </div>
-    <div class="">
-      <div class="form-control">
-        <label for="name">Name:</label>
-        <input type="text" id="name">
-      </div>
-      <div class="form-control">
-        <label>HAP Service Type:</label>
-        <select id="svc_type">
-          <option id="svc_type_-1" value="-1">Disabled</option>
-          <option id="svc_type_0" value="0">Switch</option>
-          <option id="svc_type_1" value="1">Outlet</option>
-          <option id="svc_type_2" value="2">Lock</option>
-          <option id="svc_type_3" value="3">Valve</option>
-        </select>
-      </div>
-      <div class="form-control" id="valve_type_container" style="display: none">
-        <label id="valve_type_label"></label>
-        <select id="valve_type">
-          <option id="valve_type_0" value="0">Generic Valve</option>
-          <option id="valve_type_1" value="1">Irrigation</option>
-          <option id="valve_type_2" value="2">Shower Head</option>
-          <option id="valve_type_3" value="3">Water Faucet</option>
-        </select>
-      </div>
-      <div class="form-control" id="in_mode_container">
-        <label for="in_mode">Input Mode:</label>
-        <select id="in_mode">
-          <option id="in_mode_0" value="0">Momentary</option>
-          <option id="in_mode_1" value="1">Toggle</option>
-          <option id="in_mode_2" value="2">Edge</option>
-          <option id="in_mode_3" value="3">Detached</option>
-          <option id="in_mode_4" value="4">Activation</option>
-        </select>
-      </div>
-      <div class="form-control" id="in_inverted_container" style="display: none">
-        <label for="in_inverted">Inverted Input:</label>
-        <label class="switch">
-          <input type="checkbox" id="in_inverted">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label for="initial">Initial state:</label>
-        <select id="initial">
-          <option id="initial_0" value="0">Off</option>
-          <option id="initial_1" value="1">On</option>
-          <option id="initial_2" value="2">Last</option>
-          <option id="initial_3" value="3">Input</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label for="auto_off">Auto off:</label>
-        <label class="switch">
-          <input type="checkbox" id="auto_off">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control" id="auto_off_delay_container">
-        <label for="auto_off_delay">Auto off delay:</label>
-        <input type="text" id="auto_off_delay" placeholder="D:HH:MM:SS.sss" required
-               pattern="[0-9]+:(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}">
-      </div>
-      <div class="form-control" id="state_led_en_container">
-        <label for="state_led_en">State LED:</label>
-        <label class="switch">
-          <input type="checkbox" id="state_led_en">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+      connect() {
+        this.socket = new WebSocket(`ws://${this.app.state.remoteHost}/rpc`);
+        this.socket.onopen = () => {
+          this.getInfo();
+          setInterval(() => this.getInfo(), 1000);
+        }
+        this.socket.onerror = () => this.updateState({connected: false});
+        this.socket.onclose = () => {
+          this.updateState({connected: false});
+          setInterval(() => this.reconnect(), 1000);
+        };
+        this.socket.addEventListener('message', ((responce) => this.onMessage(responce)));
+      }
 
-<div class="container" id="ssw_template" style="display: none">
-  <a class="helpbadge"
-     href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Input-Switch-Settings#stateless-switch"
-     target="_blank">?</a>
-  <h1 id="head">Input</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>HAP Type:</label>
-        <select id="type">
-          <option id="type_6" value="6">Disabled</option>
-          <option id="type_3" value="3">Stateless Switch</option>
-          <option id="type_7" value="7">Motion Sensor</option>
-          <option id="type_8" value="8">Occupancy Sensor</option>
-          <option id="type_9" value="9">Contact Sensor</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label>Name:</label>
-        <input type="text" id="name">
-      </div>
-      <div class="form-control">
-        <label>Input Mode:</label>
-        <select id="in_mode">
-          <option id="in_mode_0" value="0">Momentary</option>
-          <option id="in_mode_1" value="1">Toggle, on = off = single press</option>
-          <option id="in_mode_2" value="2">Toggle, on = single, off = double</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label for="inverted">Inverted Input:</label>
-        <label class="switch">
-          <input type="checkbox" id="inverted">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label>Last Event:</label>
-        <span id="last_event"></span>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+      reconnect() {
+        this.socket = new WebSocket(`ws://${this.app.state.remoteHost}/rpc`);
+        this.socket.onerror = () => {}
+        this.socket.onopen = () => location.reload();
+      }
 
-<div class="container" id="di_template" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Input-Switch-Settings"
-     target="_blank">?</a>
-  <h1 id="head">Disabled Input</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>HAP Type:</label>
-        <select id="type">
-          <option id="type_6" value="6">Disabled</option>
-          <option id="type_3" value="3">Stateless Switch</option>
-          <option id="type_7" value="7">Motion Sensor</option>
-          <option id="type_8" value="8">Occupancy Sensor</option>
-          <option id="type_9" value="9">Contact Sensor</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+      send(method, params = {}, callback = null) {
+        let requestId = this.requestId++;
+        let message = JSON.stringify({ method, id: requestId, params })
+        if(callback != null) this.callbacks[requestId] = callback;
+        this.socket.send(message);
+      }
 
-<div class="container" id="sensor_template" style="display: none">
-  <a class="helpbadge"
-     href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Input-Switch-Settings#motion-sensor--occupancy-sensor--contact-sensor"
-     target="_blank">?</a>
-  <h1 id="head">Sensor</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>HAP Type:</label>
-        <select id="type">
-          <option id="type_6" value="6">Disabled</option>
-          <option id="type_3" value="3">Stateless Switch</option>
-          <option id="type_7" value="7">Motion Sensor</option>
-          <option id="type_8" value="8">Occupancy Sensor</option>
-          <option id="type_9" value="9">Contact Sensor</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label>Name:</label>
-        <input type="text" id="name">
-      </div>
-      <div class="form-control">
-        <label for="inverted">Inverted Input:</label>
-        <label class="switch">
-          <input type="checkbox" id="inverted">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label>Input Mode:</label>
-        <select id="in_mode">
-          <option id="in_mode_0" value="0">Level</option>
-          <option id="in_mode_1" value="1">Pulse</option>
-        </select>
-      </div>
-      <div class="form-control" id="idle_time_container">
-        <label>Idle Time:</label>
-        <input type="text" id="idle_time" style="width: 2em; min-width: 2em"> s
-      </div>
-      <div class="form-control">
-        <label>Status:</label>
-        <span id="status"></span>
-      </div>
-      <div class="form-control">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+      getInfo() {
+        this.send("Shelly.GetInfo");
+      }
 
-<div class="container" id="wc_template" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Roller-Shutter-Settings"
-     target="_blank">?</a>
-  <h1 id="head">Window</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Name:</label>
-        <input type="text" id="name">
-      </div>
-      <div class="form-control">
-        <label>Status:</label>
-        <span id="state"></span> pos
-        <span id="pos"></span>
-      </div>
-      <div class="form-control" id="pos_ctl">
-        <label></label>
-        <button class="btn" id="open_btn">
-          <label><span id="open_spinner"></span>Open</label>
-        </button>
-        <button class="btn" id="close_btn">
-          <label><span id="close_spinner"></span>Close</label>
-        </button>
-      </div>
-      <div class="form-control">
-        <label>Calibration:</label>
-        <span id="cal"></span>
-      </div>
-      <div class="form-control">
-        <label>Input Mode:</label>
-        <select id="in_mode">
-          <option id="in_mode_0" value="0">Separate - momentary</option>
-          <option id="in_mode_1" value="1">Separate - toggle</option>
-          <option id="in_mode_2" value="2">Single</option>
-          <option id="in_mode_3" value="3">Detached</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label>Swap Inputs:</label>
-        <label class="switch">
-          <input type="checkbox" id="swap_inputs">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control">
-        <label>Swap Outputs:</label>
-        <label class="switch">
-          <input type="checkbox" id="swap_outputs">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="form-control" id="btns">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-        <button class="btn" id="cal_btn">
-          <label><span id="cal_spinner"></span>Calibrate</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+      setConfig(config, completeHandler) {
+        this.send("Shelly.SetConfig", { config }, completeHandler);
+      }
 
-<div class="container" id="gdo_template" style="display: none">
-  <a class="helpbadge" href="https://github.com/mongoose-os-apps/shelly-homekit/wiki/Garage-Door-Opener-Settings"
-     target="_blank">?</a>
-  <h1 id="head">Garage Door</h1>
-  <div class="form">
-    <div class="">
-      <div class="form-control">
-        <label>Name:</label>
-        <input type="text" id="name">
-      </div>
-      <div class="form-control">
-        <label>Status:</label>
-        <span id="state"></span>
-      </div>
-      <div class="form-control">
-        <label>Close Sensor:</label>
-        <select id="close_sensor_mode">
-          <option id="close_sensor_mode_0" value="0">Normally Closed</option>
-          <option id="close_sensor_mode_1" value="1">Normally Open</option>
-        </select>
-      </div>
-      <div class="form-control" id="open_sensor_mode_container">
-        <label>Open Sensor:</label>
-        <select id="open_sensor_mode">
-          <option id="open_sensor_mode_0" value="0">Normally Closed</option>
-          <option id="open_sensor_mode_1" value="1">Normally Open</option>
-          <option id="open_sensor_mode_2" value="2">Disabled</option>
-        </select>
-      </div>
-      <div class="form-control" id="out_mode_container">
-        <label>Output Mode:</label>
-        <select id="out_mode">
-          <option id="out_mode_0" value="0">Single</option>
-          <option id="out_mode_1" value="1">Dual</option>
-        </select>
-      </div>
-      <div class="form-control">
-        <label>Movement Time:</label>
-        <input type="text" id="move_time" style="width: 2em; min-width: 2em;"> seconds
-      </div>
-      <div class="form-control">
-        <label>Pulse Time:</label>
-        <input type="text" id="pulse_time_ms" style="width: 2em; min-width: 2em;"> ms
-      </div>
-      <div class="form-control" id="btns">
-        <label></label>
-        <button class="btn" id="save_btn">
-          <label><span id="save_spinner"></span>Save</label>
-        </button>
-        <button class="btn" id="toggle_btn">
-          <label><span id="toggle_spinner"></span>Toggle</label>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-<!-- script.js inserted below during build -->
-<script src="script.js"></script>
+      onMessage({ data }) {
+        let { id, result } = JSON.parse(data);
+        this.handleCallback(id);
+        this.updateState({...result, loaded: true, connected: true})
+      }
+
+      handleCallback(id) {
+        let callback = this.callbacks[id];
+        if(callback) {
+          callback();
+          delete this.callbacks[id];
+        }
+      }
+
+      updateState(newState) {
+        this.app.setState({...this.app.state, ...newState});
+      }
+    }
+    const apiClient = new ApiClient();
+
+    var Helper = {
+      nDigitString: function(num, digits) {
+        return num.toString().padStart(digits, "0");
+      },
+
+      durationStr: function(d) {
+        var days = parseInt(d / 86400);
+        d %= 86400;
+        var hours = parseInt(d / 3600);
+        d %= 3600;
+        var mins = parseInt(d / 60);
+        var secs = d % 60;
+        return days + ":" +
+          Helper.nDigitString(hours, 2) + ":" +
+          Helper.nDigitString(mins, 2) + ":" +
+          Helper.nDigitString(secs, 2);
+      },
+
+      yesNo: function(bool) {
+        return bool ? "Yes" : "No";
+      }
+    }
+
+    function useForm(fields) {
+      const [state, setState] = useState(fields);
+
+      const useSpinner = (action) => {
+        const [spin, setSpin] = useState(false);
+        const completeHandler = () => setSpin(false);
+        const actionHandler = () => { setSpin(true); action(completeHandler) };
+        return { spin, actionHandler }
+      }
+
+      const setField = (fieldName, property = 'value', callback = null) => {
+        return (e) => {
+          setState({...state, [fieldName]: e.target[property]});
+          if(callback != null) callback();
+        }
+      }
+
+      const bindInput = (fieldName) => {
+        return { value: state[fieldName], onInput: setField(fieldName) };
+      }
+
+      const bindSelect = (fieldName) => {
+        return { select: state[fieldName], onChange: setField(fieldName) };
+      }
+
+      const bindSwitch = (fieldName, action) => {
+        if (action == undefined) {
+          var spin = null;
+          var actionHandler = (() => {});
+        } else {
+          var { spin, actionHandler } = useSpinner(action);
+        }
+        return { spin, checked: state[fieldName], onClick: setField(fieldName, 'checked', actionHandler) };
+      }
+
+      const bindButton = (action) => {
+        const { spin, actionHandler } = useSpinner(action);
+        return { spin, onClick: actionHandler };
+      }
+
+      const getFormData = () => {
+        return Object.fromEntries(
+          Object.entries({...fields, ...state})
+          .filter(([key]) => Object.keys(fields).includes(key))
+        )
+      }
+
+      return { getFormData, state, bindInput, bindSelect, bindButton, bindSwitch };
+    }
+
+    render(html`<${App} />`, document.body);
+  </script>
+</head>
+<body>
+
 </body>
 </html>

--- a/fs_src/style.css
+++ b/fs_src/style.css
@@ -42,6 +42,10 @@ input[type=password], input[type=text] {
   font-size: 14px;
 }
 
+input[type=file] {
+  width: 200px;
+}
+
 h1 {
   margin: 0;
   padding-top: 0.5em;
@@ -54,6 +58,20 @@ h1 {
   max-width: 640px;
   background: #fefefe;
   border-radius: 10px;
+  position: relative;
+}
+
+.container:first-child {
+  display: flex;
+  flex-flow: column;
+}
+
+.container:first-child > h1 {
+  order: 1;
+}
+
+.container:first-child h1 {
+  padding: 0;
 }
 
 .form-control {
@@ -122,10 +140,10 @@ a.badge {
   padding: 6px 6px 1px 6px;
   text-align: center;
   min-width: 8px;
-  position: relative;
+  position: absolute;
   margin-top: 4px;
   margin-right: -10px;
-  float: right;
+  right: 1em;
 }
 
 #header_container {
@@ -142,10 +160,20 @@ a.badge {
 
 #logo {
   display: block;
-  margin: 8px;
+  margin: 0 8px;
   float: left;
   width: 80px;
   height: 80px;
+}
+
+.spinner_container {
+  display: inline-block;
+  position: relative;
+}
+
+.spinner_container .spin {
+  border: 0.15em solid rgba(0, 0, 0, .2);
+  border-top-color: #777;
 }
 
 .spin {


### PR DESCRIPTION
As already discussed in https://github.com/mongoose-os-apps/shelly-homekit/issues/443, the current frontend system reaches his limits. With this PR I want to show how a new system based on preact can look like.

Currently I expect that everything except the components is working. This PR is based on a commit from 12.02.2021, there are some uncovered changes in the mean time, which will be updated soon.

I assume that the footprint size of the preact version will be the same or maybe even better then the current footprint size.

@rojer If you like it and give it a 👍, I will continue the work and close the feature gap to the current UI.

Fore me the benefits are:
1. Reuse of UI components, which reduces the redundancy of html fragments
2. Simplified implicit binding between data and ui
3. more object oriented coding approach then the current spaghetti code