### PR TITLE
[Flashscript] Version 2.7.0

### DIFF
--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -615,21 +615,22 @@ class Main:
     return major, minor, patch, variant, var_seq
 
   def is_newer(self, v1, v2):
-    logger.trace(f"is: {v1}  newer than: {v2}")
     vi1 = self.parse_version(v1)
     vi2 = self.parse_version(v2)
     if vi1[0] != vi2[0]:
-      return vi1[0] > vi2[0]
+      value = vi1[0] > vi2[0]
     elif vi1[1] != vi2[1]:
-      return vi1[1] > vi2[1]
+      value = vi1[1] > vi2[1]
     elif vi1[2] != vi2[2]:
-      return vi1[2] > vi2[2]
+      value = vi1[2] > vi2[2]
     elif vi1[3] != vi2[3]:
-      return True
+      value = True
     elif vi1[4] != vi2[4]:
-      return vi1[4] > vi2[4]
+      value = vi1[4] > vi2[4]
     else:
-      return False
+      value = False
+    logger.trace(f"is {v1} newer than {v2}: {value}")
+    return value
 
   def write_network_type(self, device_info):
     logger.debug(f"{PURPLE}[Write Network Type]{NC}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2021 Andrew Blackburn, Deomid "rojer" Ryabkov & Timo Schilling
+Copyright (c) 2021 Shelly-HomeKit Contributors
 All rights reserved
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -313,12 +313,14 @@ class Device:
 
   @staticmethod
   def parse_stock_version(version):
-    # stock can be '20201124-092159/v1.9.0@57ac4ad8', we need '1.9.0'
-    # stock can be '20201124-092159/v1.9.5-DM2_autocheck', we need '1.9.5-DM2'
-    # stock can be '20210107-122133/1.9_GU10_RGBW@07531e29', we need '1.9'
-    # stock can be '20201014-165335/1244-production-Shelly1L@6a254598', we need '0.0.0'
-    # stock can be '20210226-091047/v1.10.0-rc2-89-g623b41ec0-master', we need '1.10.0-rc2'
-    # stock can be '20210318-141537/v1.10.0-geba262d', we need '1.10.0'
+    """
+    stock can be '20201124-092159/v1.9.0@57ac4ad8', we need '1.9.0'
+    stock can be '20201124-092159/v1.9.5-DM2_autocheck', we need '1.9.5-DM2'
+    stock can be '20210107-122133/1.9_GU10_RGBW@07531e29', we need '1.9'
+    stock can be '20201014-165335/1244-production-Shelly1L@6a254598', we need '0.0.0'
+    stock can be '20210226-091047/v1.10.0-rc2-89-g623b41ec0-master', we need '1.10.0-rc2'
+    stock can be '20210318-141537/v1.10.0-geba262d', we need '1.10.0'
+    """
     v = re.search(r'/.*?(?P<ver>([0-9]+\.)([0-9]+)(\.[0-9]+)?(-[a-z0-9]*)?)(?P<rest>([@\-_])[a-z0-9\-]*)', version, re.IGNORECASE)
     debug_info = v.groupdict() if v is not None else v
     logger.trace(f"parse stock version: {version}  group: {debug_info}")
@@ -597,8 +599,7 @@ class Main:
 
   @staticmethod
   def parse_version(vs):
-    # 1.9.2 / 1.9
-    # 1.9.3-rc3 / 2.7.0-beta1 / 2.7.0-latest / 1.9.5-DM2
+    # 1.9 / 1.9.2 / 1.9.3-rc3 / 1.9.5-DM2 / 2.7.0-beta1 / 2.7.0-latest
     try:
       v = re.search(r'^(?P<major>\d+).(?P<minor>\d+)(?:.(?P<patch>\d+))?(?:-(?P<prerelease>[a-zA-Z_]*)?(?P<prerelease_seq>\d*))?$', vs)
       debug_info = v.groupdict() if v is not None else v

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -671,10 +671,10 @@ class Main:
 
     if args.flash:
       action = 'flash'
-    elif args.list:
-      action = 'list'
     elif args.reboot:
       action = 'reboot'
+    elif args.list:
+      action = 'list'
     else:
       action = 'flash'
     args.hap_setup_code = f"{args.hap_setup_code[:3]}-{args.hap_setup_code[3:-3]}-{args.hap_setup_code[5:]}" if args.hap_setup_code and '-' not in args.hap_setup_code else args.hap_setup_code
@@ -760,7 +760,7 @@ class Main:
     elif args.hosts and args.do_all:
       message = f"{WHITE}Invalid option hostname or -a | --all not both.{NC}"
     elif args.list and args.reboot:
-      message = f"{WHITE}Invalid option -l or --reboot not both.{NC}"
+      args.list = False
     elif args.network_type:
       if args.do_all:
         message = f"{WHITE}Invalid option -a | --all can not be used with --ip-type.{NC}"

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -415,7 +415,7 @@ class Device:
             logger.debug(f"zipfile: {name}")
             mfile = zfile.read(name)
             manifest_file = json.loads(mfile)
-            logger.debug(f"manifest: {json.dumps(manifest_file, indent=4)}")
+            logger.debug(f"manifest: {json.dumps(manifest_file, indent=2)}")
             break
       manifest_version = manifest_file.get('version', '0.0.0')
       manifest_name = manifest_file.get('name')
@@ -841,7 +841,7 @@ class Main:
         release_info = json.loads(fp.content)
     except requests.exceptions.RequestException as err:
       logger.critical(f"{RED}CRITICAL:{NC} {err}")
-    logger.trace(f"{info_type} release_info: {json.dumps(release_info, indent=4)}")
+    logger.trace(f"{info_type} release_info: {json.dumps(release_info, indent=2)}")
     if not release_info:
       logger.error("")
       logger.error(f"{RED}Failed to lookup online stock firmware information{NC}")
@@ -1171,7 +1171,7 @@ class Main:
   def probe_device(self, device):
     logger.debug("")
     logger.debug(f"{PURPLE}[Probe Device] {device.get('host')}{NC}")
-    logger.trace(f"device_info: {json.dumps(device, indent=4)}")
+    logger.trace(f"device_info: {json.dumps(device, indent=2)}")
 
     global stock_release_info, homekit_release_info, tried_to_get_remote_homekit, tried_to_get_remote_stock, http_server_started, webserver_port, server, thread, flash_question
     requires_upgrade = False

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -602,14 +602,14 @@ class Main:
   def parse_version(vs):
     # 1.9 / 1.9.2 / 1.9.3-rc3 / 1.9.5-DM2 / 2.7.0-beta1 / 2.7.0-latest
     try:
-      v = re.search(r'^(?P<major>\d+).(?P<minor>\d+)(?:.(?P<patch>\d+))?(?:-(?P<prerelease>[a-zA-Z_]*)?(?P<prerelease_seq>\d*))?$', vs)
+      v = re.search(r'^(?P<major>\d+).(?P<minor>\d+)(?:.(?P<patch>\d+))?(?:-(?P<pr>[a-zA-Z_]*)?(?P<pr_seq>\d*))?$', vs)
       debug_info = v.groupdict() if v is not None else v
       logger.trace(f"parse version: {vs}  group: {debug_info}")
       major = int(v.group('major'))
       minor = int(v.group('minor'))
       patch = int(v.group('patch')) if v.group('patch') is not None else 0
-      variant = v.group('prerelease')
-      var_seq = int(v.group('prerelease_seq')) if v.group('prerelease_seq') and v.group('prerelease_seq').isdigit() else 0
+      variant = v.group('pr')
+      var_seq = int(v.group('pr_seq')) if v.group('pr_seq') and v.group('pr_seq').isdigit() else 0
     except Exception:
       major = 0
       minor = 0

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -499,6 +499,8 @@ class HomeKitDevice(Device):
       return False
     self.fw_type_str = 'HomeKit'
     self.fw_version = self.info.get('version', '0.0.0')
+    if self.info.get('stock_fw_model') is None:  # TODO remove once 2.9.x is mainstream.
+      self.info['stock_fw_model'] = self.info.get('stock_model')
     self.info['sys_mode_str'] = self.get_mode(self.info.get('sys_mode'))
     return True
 

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1276,7 +1276,7 @@ class Main:
             tried_to_get_remote_stock = True
           if stock_release_info:
             device_info.update_stock(stock_release_info)
-            if device_info.info.get('color_mode') == 'white' and self.flash_mode == 'homekit':
+            if device_info.info.get('device', {}).get('type', '') == 'SHRGBW2' and device_info.info.get('color_mode') == 'white':
               requires_mode_change = True
             if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
               requires_upgrade = True

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -389,6 +389,8 @@ class Device:
                'SHBLB-1': ['ShellyBulb', 'bulb'],
                'SHCB-1': ['ShellyColorBulb', 'color-bulb'],
                'SHRGBW2': ['ShellyRGBW2', 'rgbw2'],
+               'SHRGBW2-color': ['ShellyRGBW2', 'rgbw2-color'],
+               'SHRGBW2-white': ['ShellyRGBW2', 'rgbw2-white'],
                'SHRGBWW-01': ['ShellyRGBWW', 'rgbww'],
                'SH2LED-1': ['ShellyLED', 'led1'],
                'SHDM-1': ['ShellyDimmer', 'dimmer'],

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -53,7 +53,7 @@ optional arguments:
   -y, --assume-yes      Do not ask any confirmation to perform the flash.
   -V VERSION, --version VERSION
                         Force a particular version.
-  --variant VARIANT     Prerelease variant name.
+  --variant VARIANT     Pre-release variant name.
   --local-file LOCAL_FILE
                         Use local file to flash.
   -c HAP_SETUP_CODE, --hap-setup-code HAP_SETUP_CODE
@@ -1098,7 +1098,7 @@ if __name__ == '__main__':
   parser.add_argument('-n', '--assume-no', action="store_true", dest='dry_run', default=False, help="Do a dummy run through.")
   parser.add_argument('-y', '--assume-yes', action="store_true", dest='silent_run', default=False, help="Do not ask any confirmation to perform the flash.")
   parser.add_argument('-V', '--version', type=str, action="store", dest="version", default=False, help="Force a particular version.")
-  parser.add_argument('--variant', action="store", dest="variant", default=False, help="Prerelease variant name.")
+  parser.add_argument('--variant', action="store", dest="variant", default=False, help="Pre-release variant name.")
   parser.add_argument('--local-file', action="store", dest="local_file", default=False, help="Use local file to flash.")
   parser.add_argument('-c', '--hap-setup-code', action="store", dest="hap_setup_code", default=False, help="Configure HomeKit setup code, after flashing.")
   parser.add_argument('--ip-type', action="store", choices=['dhcp', 'static'], dest="network_type", default=False, help="Configure network IP type (Static or DHCP)")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2021 Andrew Blackburn & Deomid "rojer" Ryabkov
+Copyright (c) 2021 Andrew Blackburn, Deomid "rojer" Ryabkov & Timo Schilling
 All rights reserved
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -491,7 +491,7 @@ class HomeKitDevice(Device):
     self.fw_type_str = 'HomeKit'
     self.fw_version = self.info.get('version', '0.0.0')
     self.info['sys_mode_str'] = self.get_mode(self.info.get('sys_mode'))
-    if self.info.get('stock_fw_model') is None: # TODO REMOVE AFTER MAY 2021
+    if self.info.get('stock_fw_model') is None:  # TODO REMOVE AFTER MAY 2021
       self.info['stock_fw_model'] = self.info.get('stock_model')
     self.info['color_mode'] = 'color' if self.info.get('stock_fw_model').startswith('SHRGBW2') else None
     return True

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1210,24 +1210,20 @@ class Main:
         if thread is None:
           thread = threading.Thread(None, server.run)
           thread.start()
-      if self.local_file and device_info.parse_local_file():
-        if device_info.is_stock():
-          if device_info.is_homekit():
-            if not stock_release_info and not tried_to_get_remote_stock:
-              stock_release_info = self.get_release_info('stock')
-              tried_to_get_remote_stock = True
-            if stock_release_info:
-              device_info.update_stock(stock_release_info)
-              if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
-                requires_upgrade = True
-                got_info = True
-              else:
-                device_info.parse_local_file()
-                got_info = True
-          elif device_info.is_stock():
-            got_info = True
-        else:
+      if self.local_file:
+        if device_info.is_homekit() and device_info.parse_local_file():
           got_info = True
+        else:
+          if not stock_release_info and not tried_to_get_remote_stock:
+            stock_release_info = self.get_release_info('stock')
+            tried_to_get_remote_stock = True
+          if stock_release_info:
+            device_info.update_stock(stock_release_info)
+            if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
+              requires_upgrade = True
+              got_info = True
+            elif device_info.parse_local_file():
+              got_info = True
       else:
         if device_info.is_stock() and self.flash_mode == 'homekit':
           if not stock_release_info and not tried_to_get_remote_stock:

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -744,7 +744,6 @@ class Main:
   def parse_info(self, device_info, requires_upgrade):
     logger.debug(f"")
     logger.debug(f"{PURPLE}[Parse Info]{NC}")
-    logger.trace(f"device_info: {device_info}")
 
     global total_devices, flash_question
     total_devices += 1

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1043,13 +1043,13 @@ class Main:
       logger.info(f"Log file created: {args.log_filename}")
 
   def is_fw_type(self, fw_type):
-    return(fw_type.lower() in self.fw_type_filter.lower() or self.fw_type_filter == 'all')
+    return fw_type.lower() in self.fw_type_filter.lower() or self.fw_type_filter == 'all'
 
   def is_model_type(self, fw_model):
-    return(self.model_type_filter is not None and self.model_type_filter.lower() in fw_model.lower() or self.model_type_filter == 'all')
+    return self.model_type_filter is not None and self.model_type_filter.lower() in fw_model.lower() or self.model_type_filter == 'all'
 
   def is_device_name(self, device_name):
-    return(device_name is not None and self.device_name_filter is not None and self.device_name_filter.lower() in device_name.lower() or self.device_name_filter == 'all')
+    return device_name is not None and self.device_name_filter is not None and self.device_name_filter.lower() in device_name.lower() or self.device_name_filter == 'all'
 
   def device_scan(self):
     global total_devices

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -486,7 +486,18 @@ class HomeKitDevice(Device):
     self.fw_type_str = 'HomeKit'
     self.fw_version = self.info.get('version', '0.0.0')
     self.info['color_mode'] = 'color'
+    self.info['sys_mode_str'] = self.get_mode(self.info.get('sys_mode'))
     return True
+
+  @staticmethod
+  def get_mode(mode):
+    options = {0: 'Switch',
+               1: 'Roller Shutter',
+               2: 'Garage Door',
+               3: 'RGB',
+               4: 'RGBW'
+               }
+    return options.get(mode, mode)
 
   def flash_firmware(self):
     if self.local_file:
@@ -771,6 +782,7 @@ class Main:
     wifi_ssid = device_info.info.get('wifi_ssid')
     wifi_rssi = device_info.info.get('wifi_rssi')
     sys_temp = device_info.info.get('sys_temp')
+    sys_mode = device_info.info.get('sys_mode_str')
     uptime = datetime.timedelta(seconds=device_info.info.get('uptime', 0))
     hap_ip_conns_pending = device_info.info.get('hap_ip_conns_pending')
     hap_ip_conns_active = device_info.info.get('hap_ip_conns_active')
@@ -818,6 +830,8 @@ class Main:
         logger.info(f"{WHITE}Model: {NC}{model}")
       if self.info_level >= 3:
         logger.info(f"{WHITE}Device ID: {NC}{device_id}")
+        if sys_mode:
+          logger.info(f"{WHITE}Mode: {NC}{sys_mode}")
         logger.info(f"{WHITE}SSID: {NC}{wifi_ssid}")
         logger.info(f"{WHITE}IP: {NC}{wifi_ip}")
         logger.info(f"{WHITE}RSSI: {NC}{wifi_rssi}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -520,6 +520,7 @@ class HomeKitDevice(Device):
     return options.get(mode, mode)
 
   def flash_firmware(self, revert=False):
+    logger.trace(f"revert {revert}")
     if self.local_file:
       logger.debug(f"Local file: {self.local_file}")
       my_file = open(self.local_file, 'rb')
@@ -569,6 +570,7 @@ class StockDevice(Device):
     return self.info.get('mode')
 
   def flash_firmware(self, revert=False):
+    logger.trace(f"revert {revert}")
     logger.info(f"Now Flashing {self.flash_fw_type_str} {self.flash_fw_version}")
     response = None
     download_url = self.download_url.replace('https', 'http')

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -987,6 +987,7 @@ class Main:
     global total_devices, flash_question
     if device_info.already_processed is False:
       total_devices += 1
+      flash_question = None
 
     perform_flash = False
     do_mode_change = False

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1288,7 +1288,7 @@ class Main:
           if not stock_release_info and not tried_to_get_remote_stock:
             stock_release_info = self.get_release_info('stock')
             tried_to_get_remote_stock = True
-          if not homekit_release_info and not tried_to_get_remote_homekit and not self.local_file:
+          if not homekit_release_info and not tried_to_get_remote_homekit:
             homekit_release_info = self.get_release_info('homekit')
             tried_to_get_remote_homekit = True
           if stock_release_info and homekit_release_info:

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -991,7 +991,6 @@ class Main:
 
     perform_flash = False
     do_mode_change = False
-    flash_question = None
     download_url_request = False
     host = device_info.host
     wifi_ip = device_info.wifi_ip
@@ -1168,14 +1167,16 @@ class Main:
         else:
           logger.trace('TEST A22')
           flash_message = f"Do you wish to flash {friendly_host} to {flash_fw_type_str} firmware version {flash_fw_version}"
-        logger.trace('TEST A23')
-        if flash_question is None and input(f"{flash_message} (y/n) ? ") in ('y', 'Y'):
-          logger.trace('TEST A24')
-          flash_question = True
-        else:
-          logger.trace('TEST A25')
-          flash_question = False
-          logger.info("Skipping Flash...")
+        logger.trace('TEST A23a')
+        if flash_question is None:
+          logger.trace('TEST A23b')
+          if input(f"{flash_message} (y/n) ? ") in ('y', 'Y'):
+            logger.trace('TEST A24')
+            flash_question = True
+          else:
+            logger.trace('TEST A25')
+            flash_question = False
+            logger.info("Skipping Flash...")
       elif (perform_flash is True or do_mode_change is True) and self.dry_run is False and self.silent_run is True:
         logger.trace('TEST A26')
         flash_question = True

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -496,7 +496,7 @@ class HomeKitDevice(Device):
     self.fw_type_str = 'HomeKit'
     self.fw_version = self.info.get('version', '0.0.0')
     self.info['sys_mode_str'] = self.get_mode(self.info.get('sys_mode'))
-    if self.info.get('stock_fw_model') is None:
+    if self.info.get('stock_fw_model') is None: # TODO REMOVE AFTER MAY 2021
       self.info['stock_fw_model'] = self.info.get('stock_model')
     self.info['color_mode'] = 'color' if self.info.get('stock_fw_model').startswith('SHRGBW2') else None
     return True
@@ -718,7 +718,7 @@ class Main:
     if args.verbose >= 4:
       args.info_level = 3
     if args.log_filename:
-      fh = MFileHandler(args.log_filename, mode='w', encoding='utf-8')
+      fh = MFileHandler(args.log_filename, mode='w', encoding='UTF-8')
       fh.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(lineno)d %(message)s'))
       fh.setLevel(log_level[args.verbose])
       logger.addHandler(fh)

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -392,6 +392,7 @@ class Device:
   def update_homekit(self, release_info=None):
     self.flash_fw_type_str = 'HomeKit'
     self.flash_fw_type = 'homekit'
+    logger.debug(f"Mode: {self.fw_type_str} To {self.flash_fw_type_str}")
     if not self.version:
       for i in release_info:
         if self.variant and self.variant not in i[1]['version']:
@@ -413,6 +414,7 @@ class Device:
   def update_stock(self, release_info=None):
     self.flash_fw_type_str = 'Stock'
     self.flash_fw_type = 'stock'
+    logger.debug(f"Mode: {self.fw_type_str} To {self.flash_fw_type_str}")
     if not self.version:
       stock_model_info = release_info['data'][self.stock_model] if self.stock_model in release_info['data'] else None
       if self.variant == 'beta':
@@ -445,14 +447,6 @@ class HomeKitDevice(Device):
     self.device_name = self.info['name'] if 'name' in self.info else None
     self.color_mode = self.info['color_mode'] if 'color_mode' in self.info else None
     return True
-
-  def update_to_homekit(self, release_info=None):
-    logger.debug("Mode: HomeKit To HomeKit")
-    self.update_homekit(release_info)
-
-  def update_to_stock(self, release_info=None):
-    logger.debug("Mode: HomeKit To Stock")
-    self.update_stock(release_info)
 
   def flash_firmware(self):
     if self.local_file:
@@ -489,14 +483,6 @@ class StockDevice(Device):
     self.device_name = self.info['name'] if 'name' in self.info else None
     self.color_mode = self.info['mode'] if 'mode' in self.info else None
     return True
-
-  def update_to_homekit(self, release_info=None):
-    logger.debug("Mode: Stock To HomeKit")
-    self.update_homekit(release_info)
-
-  def update_to_stock(self, release_info=None):
-    logger.debug("Mode: Stock To Stock")
-    self.update_stock(release_info)
 
   def flash_firmware(self):
     logger.info("Now Flashing...")
@@ -955,7 +941,7 @@ class Main():
               stock_release_info = self.get_release_info('stock')
               tried_to_get_remote_stock = True
             if stock_release_info:
-              deviceinfo.update_to_stock(stock_release_info)
+              deviceinfo.update_stock(stock_release_info)
               if (deviceinfo.fw_version == '0.0.0' or self.is_newer(deviceinfo.flash_fw_version, deviceinfo.fw_version)):
                 requires_upgrade = True
                 got_info = True
@@ -975,26 +961,26 @@ class Main():
             homekit_release_info = self.get_release_info('homekit')
             tried_to_get_remote_homekit = True
           if stock_release_info and homekit_release_info:
-            deviceinfo.update_to_stock(stock_release_info)
+            deviceinfo.update_stock(stock_release_info)
             if (deviceinfo.fw_version == '0.0.0' or self.is_newer(deviceinfo.flash_fw_version, deviceinfo.fw_version)):
               requires_upgrade = True
               got_info = True
             else:
-              deviceinfo.update_to_homekit(homekit_release_info)
+              deviceinfo.update_homekit(homekit_release_info)
               got_info = True
         elif self.flashmode == 'homekit':
           if not homekit_release_info and not tried_to_get_remote_homekit and not self.local_file:
             homekit_release_info = self.get_release_info('homekit')
             tried_to_get_remote_homekit = True
           if homekit_release_info:
-            deviceinfo.update_to_homekit(homekit_release_info)
+            deviceinfo.update_homekit(homekit_release_info)
             got_info = True
         elif self.flashmode == 'stock':
           if not stock_release_info and not tried_to_get_remote_stock:
             stock_release_info = self.get_release_info('stock')
             tried_to_get_remote_stock = True
           if stock_release_info:
-            deviceinfo.update_to_stock(stock_release_info)
+            deviceinfo.update_stock(stock_release_info)
             got_info = True
       if got_info and deviceinfo.fw_type == "homekit" and float(f"{self.parse_version(deviceinfo.info['version'])[0]}.{self.parse_version(deviceinfo.info['version'])[1]}") < 2.1:
         logger.error(f"{WHITE}Host: {NC}{deviceinfo.host}")
@@ -1130,7 +1116,7 @@ if __name__ == '__main__':
 
   homekit_release_info = None
   stock_release_info = None
-  app_version = "2.6.3"
+  app_version = "2.6.4"
 
   logger.debug(f"OS: {PURPLE}{arch}{NC}")
   logger.debug(f"app_version: {app_version}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -513,6 +513,7 @@ class HomeKitDevice(Device):
     return options.get(mode, mode)
 
   def flash_firmware(self, revert=False):
+    logger.trace(f'revert to stock: {revert}')
     if self.local_file:
       logger.debug(f"Local file: {self.local_file}")
       my_file = open(self.local_file, 'rb')
@@ -563,6 +564,7 @@ class StockDevice(Device):
     return self.info.get('mode')
 
   def flash_firmware(self, revert=False):
+    logger.trace(f'revert to stock: {revert}')
     logger.info(f"Now Flashing {self.flash_fw_type_str} {self.flash_fw_version}")
     response = None
     download_url = self.download_url.replace('https', 'http')
@@ -702,6 +704,7 @@ class Main:
     logger.debug(f"manual_hosts: {args.hosts} ({len(args.hosts)})")
     logger.debug(f"action: {action}")
     logger.debug(f"mode: {args.mode}")
+    logger.debug(f"timeout: {args.timeout}")
     logger.debug(f"info_level: {args.info_level}")
     logger.debug(f"fw_type_filter: {args.fw_type_filter}")
     logger.debug(f"model_type_filter: {args.model_type_filter}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -981,7 +981,7 @@ class Main:
       global requires_mode_change
       requires_mode_change = 'Done'
 
-  def parse_info(self, device_info):
+  def parse_info(self, device_info, hk_ver=None):
     logger.debug(f"")
     logger.debug(f"{PURPLE}[Parse Info]{NC}")
 
@@ -1050,6 +1050,9 @@ class Main:
       latest_fw_label = f"{RED}Not available{NC}"
       flash_fw_version = '0.0.0'
       download_url = None
+    elif hk_ver is not None:
+      latest_fw_label = hk_ver
+      flash_fw_type_str = "HomeKit"
     else:
       latest_fw_label = flash_fw_version
 
@@ -1233,6 +1236,7 @@ class Main:
     requires_upgrade = False
     requires_mode_change = False
     got_info = False
+    hk_flash_fw_version = None
 
     if self.mode == 'keep':
       self.flash_mode = device.get('fw_type')
@@ -1288,6 +1292,11 @@ class Main:
             homekit_release_info = self.get_release_info('homekit')
             tried_to_get_remote_homekit = True
           if stock_release_info and homekit_release_info:
+            device_info.update_homekit(homekit_release_info)
+            if device_info.download_url:
+              download_url_request = requests.head(device_info.download_url)
+              logger.debug(f"download_url_request: {download_url_request}")
+              hk_flash_fw_version = device_info.flash_fw_version
             device_info.update_stock(stock_release_info)
             if device_info.info.get('device', {}).get('type', '') == 'SHRGBW2' and device_info.info.get('color_mode') == 'white':
               requires_mode_change = True
@@ -1324,7 +1333,7 @@ class Main:
         logger.trace('TEST 1')
         logger.trace(f"requires_upgrade: {requires_upgrade}")
         logger.trace(f"requires_mode_change: {requires_mode_change}")
-        self.parse_info(device_info)
+        self.parse_info(device_info, hk_flash_fw_version)
         logger.trace('TEST 2')
         logger.trace(f"requires_upgrade: {requires_upgrade}")
         logger.trace(f"requires_mode_change: {requires_mode_change}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -786,6 +786,7 @@ class Main:
     hap_ip_conns_pending = device_info.info.get('hap_ip_conns_pending')
     hap_ip_conns_active = device_info.info.get('hap_ip_conns_active')
     hap_ip_conns_max = device_info.info.get('hap_ip_conns_max')
+    battery = None if device_info.is_homekit() else device_info.info.get('status', {}).get('bat', {}).get('value')
 
     logger.debug(f"flash mode: {self.flash_mode}")
     logger.debug(f"requires_upgrade: {requires_upgrade}")
@@ -822,11 +823,11 @@ class Main:
     if (not self.quiet_run or (self.quiet_run and (flash_fw_newer or (force_flash and flash_fw_version != '0.0.0')))) and requires_upgrade != 'Done':
       logger.info(f"")
       logger.info(f"{WHITE}Host: {NC}http://{host}")
-      if int(self.info_level) > 1 or device_name != friendly_host:
+      if self.info_level > 1 or device_name != friendly_host:
         logger.info(f"{WHITE}Device Name: {NC}{device_name}")
-      if int(self.info_level) > 1:
+      if self.info_level > 1:
         logger.info(f"{WHITE}Model: {NC}{model}")
-      if int(self.info_level) >= 3:
+      if self.info_level >= 3:
         logger.info(f"{WHITE}Device ID: {NC}{device_id}")
         logger.info(f"{WHITE}SSID: {NC}{wifi_ssid}")
         logger.info(f"{WHITE}IP: {NC}{wifi_ip}")
@@ -839,6 +840,8 @@ class Main:
           if int(hap_ip_conns_pending) > 0:
             hap_ip_conns_pending = f"{RED}{hap_ip_conns_pending}{NC}"
           logger.info(f"{WHITE}HAP Connections: {NC}{hap_ip_conns_pending} / {hap_ip_conns_active} / {hap_ip_conns_max}{NC}")
+        if battery is not None:
+          logger.info(f"{WHITE}Battery: {NC}{battery}%{NC}")
       if current_fw_type == self.flash_mode and (current_fw_version == flash_fw_version or flash_fw_version == '0.0.0'):
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version} {GREEN}\u2714{NC}")
       elif current_fw_type == self.flash_mode and flash_fw_newer:

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -68,14 +68,14 @@ optional arguments:
   --dns IPV4_DNS        set DNS IP address
   -v {0,1,2,3,4,5}, --verbose {0,1,2,3,4,5}
                         Enable verbose logging 0=critical, 1=error, 2=warning, 3=info, 4=debug, 5=trace.
-  --timeout TIMEOUT     Scan: Time of seconds to wait after last detected device before quitting.  Manual: Time of seconds to keeping to connect.
+  --timeout TIMEOUT     Scan: Time of seconds to wait after last detected device before quitting. Manual: Time of seconds to keeping to connect.
   --log-file LOG_FILENAME
                         Create output log file with chosen filename.
   --reboot              Preform a reboot of the device.
   --config CONFIG       Load options from config file.
   --save-config SAVE_CONFIG
                         Save current options to config file.
-  --delete-config-file  Delete config file..
+  --delete-config-file  Delete config file.
 """
 
 import argparse
@@ -1189,12 +1189,14 @@ if __name__ == '__main__':
       sys.exit(1)
     logger.info(f'Reading configuration section {args.config} from {config_file}')
     parser.set_defaults(mode=config.get(args.config, 'mode'), info_level=config.getint(args.config, 'info_level'), fw_type_filter=config.get(args.config, 'fw_type_filter'),
-                        model_type_filter=config.get(args.config, 'model_type_filter'), device_name_filter=config.get(args.config, 'device_name_filter'), do_all=config.getboolean(args.config, 'do_all'),
-                        quiet_run=config.getboolean(args.config, 'quiet_run'), list=config.getboolean(args.config, 'list'), exclude=config.get(args.config, 'exclude'), dry_run=config.getboolean(args.config, 'dry_run'),
-                        silent_run=config.getboolean(args.config, 'silent_run'), version=config.get(args.config, 'version'), variant=config.get(args.config, 'variant'), local_file=config.get(args.config, 'local_file'),
+                        model_type_filter=config.get(args.config, 'model_type_filter'), device_name_filter=config.get(args.config, 'device_name_filter'),
+                        do_all=config.getboolean(args.config, 'do_all'), quiet_run=config.getboolean(args.config, 'quiet_run'), list=config.getboolean(args.config, 'list'),
+                        exclude=config.get(args.config, 'exclude'), dry_run=config.getboolean(args.config, 'dry_run'), silent_run=config.getboolean(args.config, 'silent_run'),
+                        version=config.get(args.config, 'version'), variant=config.get(args.config, 'variant'), local_file=config.get(args.config, 'local_file'),
                         hap_setup_code=config.get(args.config, 'hap_setup_code'), network_type=config.get(args.config, 'network_type'), ipv4_ip=config.get(args.config, 'ipv4_ip'),
-                        ipv4_gw=config.get(args.config, 'ipv4_gw'), ipv4_mask=config.get(args.config, 'ipv4_mask'), ipv4_dns=config.get(args.config, 'ipv4_dns'), verbose=config.getint(args.config, 'verbose'),
-                        timeout=config.get(args.config, 'timeout'), log_filename=config.get(args.config, 'log_filename'), reboot=config.getboolean(args.config, 'reboot'), hosts=config.get(args.config, 'hosts').split())
+                        ipv4_gw=config.get(args.config, 'ipv4_gw'), ipv4_mask=config.get(args.config, 'ipv4_mask'), ipv4_dns=config.get(args.config, 'ipv4_dns'),
+                        verbose=config.getint(args.config, 'verbose'), timeout=config.get(args.config, 'timeout'), log_filename=config.get(args.config, 'log_filename'),
+                        reboot=config.getboolean(args.config, 'reboot'), hosts=config.get(args.config, 'hosts').split())
     args = parser.parse_args()
     arg_list = vars(args)
     logger.trace(f"Loaded config: {arg_list}")
@@ -1301,8 +1303,8 @@ if __name__ == '__main__':
     parser.print_help()
     sys.exit(1)
 
-  main = Main(args.hosts, action, args.timeout, args.log_filename, args.dry_run, args.quiet_run, args.silent_run, args.mode, args.info_level, args.fw_type_filter, args.model_type_filter, args.device_name_filter,
-              args.exclude, args.version, args.variant, args.hap_setup_code, args.local_file, args.network_type, args.ipv4_ip, args.ipv4_mask, args.ipv4_gw, args.ipv4_dns)
+  main = Main(args.hosts, action, args.timeout, args.log_filename, args.dry_run, args.quiet_run, args.silent_run, args.mode, args.info_level, args.fw_type_filter, args.model_type_filter,
+              args.device_name_filter, args.exclude, args.version, args.variant, args.hap_setup_code, args.local_file, args.network_type, args.ipv4_ip, args.ipv4_mask, args.ipv4_gw, args.ipv4_dns)
   atexit.register(main.results)
   try:
     main.device_scan()

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1263,7 +1263,7 @@ class Main:
       if self.local_file:
         if device_info.is_homekit() and device_info.parse_local_file():
           got_info = True
-        else:
+        if device_info.is_stock() and device_info.parse_local_file():
           if not stock_release_info and not tried_to_get_remote_stock:
             stock_release_info = self.get_release_info('stock')
             tried_to_get_remote_stock = True

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -123,6 +123,12 @@ logging.Logger.trace = functools.partialmethod(logging.Logger.log, logging.TRACE
 logging.trace = functools.partial(logging.log, logging.TRACE)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.TRACE)
+log_level = {'0': logging.CRITICAL,
+             '1': logging.ERROR,
+             '2': logging.WARNING,
+             '3': logging.INFO,
+             '4': logging.DEBUG,
+             '5': logging.TRACE}
 
 webserver_port = 8381
 http_server_started = False
@@ -1101,13 +1107,13 @@ if __name__ == '__main__':
 
   sh = MStreamHandler()
   sh.setFormatter(logging.Formatter('%(message)s'))
-  sh.setLevel(int(args.verbose))
+  sh.setLevel(log_level[args.verbose])
   if int(args.verbose) >= 4:
     args.info_level = 3
   if args.log_filename:
     fh = MFileHandler(args.log_filename, mode='w', encoding='utf-8')
     fh.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(lineno)d %(message)s'))
-    fh.setLevel(int(args.verbose))
+    fh.setLevel(log_level[args.verbose])
     logger.addHandler(fh)
   logger.addHandler(sh)
 

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1289,7 +1289,7 @@ class Main:
             tried_to_get_remote_homekit = True
           if stock_release_info and homekit_release_info:
             device_info.update_stock(stock_release_info)
-            if device_info.info.get('color_mode') == 'white' and self.flash_mode == 'homekit':
+            if device_info.info.get('device', {}).get('type', '') == 'SHRGBW2' and device_info.info.get('color_mode') == 'white':
               requires_mode_change = True
             if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
               requires_upgrade = True
@@ -1335,9 +1335,11 @@ class Main:
           if requires_mode_change is True:
             logger.trace('TEST 4')
             logger.info(f"Waiting for device...")
-            if device_info.info.get('stock_fw_model') == 'SHRGBW2':  # TODO check if this is still required once stock fw gets past 1.10.0-34
+            if device_info.info.get('device', {}).get('type', '') == 'SHRGBW2':  # TODO check if this is still required once stock fw gets past 1.10.0-34
+              logger.trace('TEST 5a')
               time.sleep(30)  # need to allow time for previous flash reboot to fully boot, SHRGBW2 needs extra time due to firmware self updating.
             else:
+              logger.trace('TEST 5b')
               time.sleep(15)  # need to allow time for previous flash reboot to fully boot.
             device_info.get_info()
             logger.trace(f"requires_upgrade: {requires_upgrade}")
@@ -1357,7 +1359,7 @@ class Main:
               device_info.update_homekit(homekit_release_info)
             logger.trace('TEST 9')
             logger.info(f"Waiting for device...")
-            if device_info.info.get('stock_fw_model') == 'SHRGBW2':  # TODO check if this is still required once stock fw gets past 1.10.0-34
+            if device_info.info.get('device', {}).get('type', '') == 'SHRGBW2':  # TODO check if this is still required once stock fw gets past 1.10.0-34
               time.sleep(30)  # need to allow time for previous flash reboot to fully boot, SHRGBW2 needs extra time due to firmware self updating.
             else:
               time.sleep(15)  # need to allow time for previous flash reboot to fully boot.

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1290,10 +1290,6 @@ class Main:
       logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices}{NC}")
     if self.log_filename:
       logger.info(f"Log file created: {self.log_filename}")
-    if http_server_started and server is not None:
-      logger.trace("Shutting down webserver")
-      server.shutdown()
-      thread.join()
 
   def is_fw_type(self, fw_type):
     return fw_type.lower() in self.fw_type_filter.lower() or self.fw_type_filter == 'all'
@@ -1324,6 +1320,10 @@ class Main:
       if device_info.info:
         device = {'host': device_info.host, 'wifi_ip': device_info.wifi_ip, 'fw_type': device_info.info.get('fw_type'), 'info': device_info.info}
         self.probe_device(device)
+    if http_server_started and server is not None:
+      logger.trace("Shutting down webserver")
+      server.shutdown()
+      thread.join()
 
   def device_scan(self):
     global total_devices

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -208,7 +208,7 @@ class Device:
 
   def is_host_reachable(self, host, is_flashing=False):
     # check if host is reachable
-    hostcheck = re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", host)
+    hostcheck = re.search(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', host)
     self.host = f'{host}.local' if '.local' not in host and not hostcheck else host
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(3)
@@ -277,7 +277,7 @@ class Device:
     # stock can be '20210226-091047/v1.10.0-rc2-89-g623b41ec0-master', we need '1.10.0-rc2'
     # stock can be '20210318-141537/v1.10.0-geba262d', we need '1.10.0'
     logger.trace(f"version: {version}")
-    v = re.search("/.*?(?P<ver>([0-9]+\.)([0-9]+)(\.[0-9]+)?(-[a-z0-9]*)?)(?P<rest>(@|-|_)[a-z0-9\-]*)", version, re.IGNORECASE)
+    v = re.search(r'/.*?(?P<ver>([0-9]+\.)([0-9]+)(\.[0-9]+)?(-[a-z0-9]*)?)(?P<rest>(@|-|_)[a-z0-9\-]*)', version, re.IGNORECASE)
     debug_info = v.groupdict() if v is not None else v
     logger.trace(f"stock version group: {debug_info}")
     parsed_version = v.group('ver') if v is not None else '0.0.0'
@@ -399,7 +399,7 @@ class Device:
           self.dlurl = None
           return
         if self.variant:
-          re_search = '-*'
+          re_search = r'-*'
         else:
           re_search = i[0]
         if re.search(re_search, self.fw_version):
@@ -572,7 +572,7 @@ class Main():
     # 1.9.3-rc3 / 2.7.0-beta1 / 2.7.0-latest / 1.9.5-DM2
     logger.trace(f"vs: {vs}")
     try:
-      v = re.search("^(?P<major>\d+).(?P<minor>\d+)(?:.(?P<patch>\d+))?(?:-(?P<prerelease>[a-zA-Z_]*)?(?P<prerelease_seq>\d*))?$", vs)
+      v = re.search(r'^(?P<major>\d+).(?P<minor>\d+)(?:.(?P<patch>\d+))?(?:-(?P<prerelease>[a-zA-Z_]*)?(?P<prerelease_seq>\d*))?$', vs)
       debug_info = v.groupdict() if v is not None else v
       logger.trace(f"group: {debug_info}")
       major = int(v.group('major'))

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1,70 +1,72 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2020 Andrew Blackburn & Deomid "rojer" Ryabkov
-#  All rights reserved
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
-#  This script will probe for any shelly device on the network and it will
-#  attempt to update them to the latest firmware version available.
-#  This script will not flash any firmware to a device that is not already on a
-#  version of this firmware, if you are looking to flash your device from stock
-#  or any other firmware please follow instructions here:
-#  https://github.com/mongoose-os-apps/shelly-homekit/wiki
-#
-#  usage: flash-shelly.py [-h] [-m {homekit,keep,revert}] [-t {homekit,stock,all}] [-a] [-q] [-l] [-e [EXCLUDE ...]] [-n] [-y] [-V VERSION] [--variant VARIANT] [--local-file LOCAL_FILE] [-c HAP_SETUP_CODE]
-#                         [--ip-type {dhcp,static}] [--ip IPV4_IP] [--gw IPV4_GW] [--mask IPV4_MASK] [--dns IPV4_DNS] [-v {0,1,2,3,4,5}] [--log-file LOG_FILENAME]
-#                         [hosts ...]
-#
-#  Shelly HomeKit flashing script utility
-#
-#  positional arguments:
-#    hosts
-#
-#  optional arguments:
-#    -h, --help            show this help message and exit
-#    -m {homekit,keep,revert}, --mode {homekit,keep,revert}
-#                          Script mode.
-#    -i {1,2,3}, --info-level {1,2,3}
-#                          Control how much detail is output in the list 1=minimal, 2=basic, 3=all.
-#    -ft {homekit,stock,all}, --fw-type {homekit,stock,all}
-#                          Limit scan to current firmware type.
-#    -mt MODEL_TYPE, --model-type MODEL_TYPE
-#                          Limit scan to model type (dimmer, rgbw2, shelly1, etc).
-#    -a, --all             Run against all the devices on the network.
-#    -q, --quiet           Only include upgradeable shelly devices.
-#    -l, --list            List info of shelly device.
-#    -e [EXCLUDE ...], --exclude [EXCLUDE ...]
-#                          Exclude hosts from found devices.
-#    -n, --assume-no       Do a dummy run through.
-#    -y, --assume-yes      Do not ask any confirmation to perform the flash.
-#    -V VERSION, --version VERSION
-#                          Force a particular version.
-#    --variant VARIANT     Prerelease variant name.
-#    --local-file LOCAL_FILE
-#                          Use local file to flash.
-#    -c HAP_SETUP_CODE, --hap-setup-code HAP_SETUP_CODE
-#                          Configure HomeKit setup code, after flashing.
-#    --ip-type {dhcp,static}
-#                          Configure network IP type (Static or DHCP)
-#    --ip IPV4_IP          set IP address
-#    --gw IPV4_GW          set Gateway IP address
-#    --mask IPV4_MASK      set Subnet mask address
-#    --dns IPV4_DNS        set DNS IP address
-#    -v {0,1,2,3,4,5}, --verbose {0,1,2,3,4,5}
-#                          Enable verbose logging 0=critical, 1=error, 2=warning, 3=info, 4=debug, 5=trace.
-#    --log-file LOG_FILENAME
-#                          Create output log file with chosen filename.
-#    --reboot              Preform a reboot of the device.
+"""
+Copyright (c) 2021 Andrew Blackburn & Deomid "rojer" Ryabkov
+All rights reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This script will probe for any shelly device on the network and it will
+attempt to update them to the latest firmware version available.
+This script will not flash any firmware to a device that is not already on a
+version of this firmware, if you are looking to flash your device from stock
+or any other firmware please follow instructions here:
+https://github.com/mongoose-os-apps/shelly-homekit/wiki
+
+usage: flash-shelly.py [-h] [-m {homekit,keep,revert}] [-t {homekit,stock,all}] [-a] [-q] [-l] [-e [EXCLUDE ...]] [-n] [-y] [-V VERSION] [--variant VARIANT] [--local-file LOCAL_FILE] [-c HAP_SETUP_CODE]
+                      [--ip-type {dhcp,static}] [--ip IPV4_IP] [--gw IPV4_GW] [--mask IPV4_MASK] [--dns IPV4_DNS] [-v {0,1,2,3,4,5}] [--log-file LOG_FILENAME]
+                      [hosts ...]
+
+Shelly HomeKit flashing script utility
+
+positional arguments:
+ hosts
+
+optional arguments:
+ -h, --help            show this help message and exit
+ -m {homekit,keep,revert}, --mode {homekit,keep,revert}
+                       Script mode.
+ -i {1,2,3}, --info-level {1,2,3}
+                       Control how much detail is output in the list 1=minimal, 2=basic, 3=all.
+ -ft {homekit,stock,all}, --fw-type {homekit,stock,all}
+                       Limit scan to current firmware type.
+ -mt MODEL_TYPE, --model-type MODEL_TYPE
+                       Limit scan to model type (dimmer, rgbw2, shelly1, etc).
+ -a, --all             Run against all the devices on the network.
+ -q, --quiet           Only include upgradeable shelly devices.
+ -l, --list            List info of shelly device.
+ -e [EXCLUDE ...], --exclude [EXCLUDE ...]
+                       Exclude hosts from found devices.
+ -n, --assume-no       Do a dummy run through.
+ -y, --assume-yes      Do not ask any confirmation to perform the flash.
+ -V VERSION, --version VERSION
+                       Force a particular version.
+ --variant VARIANT     Prerelease variant name.
+ --local-file LOCAL_FILE
+                       Use local file to flash.
+ -c HAP_SETUP_CODE, --hap-setup-code HAP_SETUP_CODE
+                       Configure HomeKit setup code, after flashing.
+ --ip-type {dhcp,static}
+                       Configure network IP type (Static or DHCP)
+ --ip IPV4_IP          set IP address
+ --gw IPV4_GW          set Gateway IP address
+ --mask IPV4_MASK      set Subnet mask address
+ --dns IPV4_DNS        set DNS IP address
+ -v {0,1,2,3,4,5}, --verbose {0,1,2,3,4,5}
+                       Enable verbose logging 0=critical, 1=error, 2=warning, 3=info, 4=debug, 5=trace.
+ --log-file LOG_FILENAME
+                       Create output log file with chosen filename.
+ --reboot              Preform a reboot of the device.
+"""
 
 import argparse
 import atexit
@@ -86,27 +88,34 @@ import threading
 import time
 import zipfile
 
+
 class MFileHandler(logging.FileHandler):
-  """Handler that controls the writing of the newline character"""
+  # Handler that controls the writing of the newline character
   special_code = '[!n]'
+  terminator = None
+
   def emit(self, record) -> None:
     if self.special_code in record.msg:
-      record.msg = record.msg.replace( self.special_code, '' )
+      record.msg = record.msg.replace(self.special_code, '')
       self.terminator = ''
     else:
       self.terminator = '\n'
     return super().emit(record)
 
+
 class MStreamHandler(logging.StreamHandler):
-  """Handler that controls the writing of the newline character"""
+  # Handler that controls the writing of the newline character
   special_code = '[!n]'
+  terminator = None
+
   def emit(self, record) -> None:
     if self.special_code in record.msg:
-      record.msg = record.msg.replace( self.special_code, '' )
+      record.msg = record.msg.replace(self.special_code, '')
       self.terminator = ''
     else:
       self.terminator = '\n'
     return super().emit(record)
+
 
 logging.TRACE = 5
 logging.addLevelName(logging.TRACE, 'TRACE')
@@ -114,12 +123,12 @@ logging.Logger.trace = functools.partialmethod(logging.Logger.log, logging.TRACE
 logging.trace = functools.partial(logging.log, logging.TRACE)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.TRACE)
-log_level = {'0' : logging.CRITICAL,
-             '1' : logging.ERROR,
-             '2' : logging.WARNING,
-             '3' : logging.INFO,
-             '4' : logging.DEBUG,
-             '5' : logging.TRACE}
+log_level = {'0': logging.CRITICAL,
+             '1': logging.ERROR,
+             '2': logging.WARNING,
+             '3': logging.INFO,
+             '4': logging.DEBUG,
+             '5': logging.TRACE}
 
 webserver_port = 8381
 http_server_started = False
@@ -136,30 +145,34 @@ tried_to_get_remote_homekit = False
 homekit_info_url = "https://rojer.me/files/shelly/update.json"
 homekit_release_info = None
 tried_to_get_remote_stock = False
+flash_question = None
+
 
 def upgrade_pip():
   logger.info("Updating pip...")
-  pipe = subprocess.check_output([sys.executable, '-m', 'pip', 'install', '--upgrade', 'pip'])
+  subprocess.run([sys.executable, '-m', 'pip', 'install', '--upgrade', 'pip'])
+
 
 try:
   import zeroconf
 except ImportError:
   logger.info("Installing zeroconf...")
   upgrade_pip()
-  pipe = subprocess.check_output([sys.executable, '-m', 'pip', 'install', 'zeroconf'])
+  subprocess.run([sys.executable, '-m', 'pip', 'install', 'zeroconf'])
   import zeroconf
 try:
   import requests
 except ImportError:
   logger.info("Installing requests...")
   upgrade_pip()
-  pipe = subprocess.check_output([sys.executable, '-m', 'pip', 'install', 'requests'])
+  subprocess.run([sys.executable, '-m', 'pip', 'install', 'requests'])
   import requests
 
 
 class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
-    def log_request(self, code):
-        pass
+  def log_request(self, code='-', size='-'):
+    pass
+
 
 class StoppableHTTPServer(http.server.HTTPServer):
   def run(self):
@@ -171,33 +184,33 @@ class StoppableHTTPServer(http.server.HTTPServer):
       self.server_close()
 
 
-class MyListener:
+class ServiceListener:
   def __init__(self):
     self.queue = queue.Queue()
 
-  def add_service(self, zeroconf, type, device):
-    host = device.replace(f'.{type}', '')
-    info = zeroconf.get_service_info(type, device)
+  def add_service(self, zc, service_type, device):
+    host = device.replace(f'.{service_type}', '')
+    info = zc.get_service_info(service_type, device)
     if info:
       properties = info.properties
-      properties = { y.decode('UTF-8'): properties.get(y).decode('UTF-8') for y in properties.keys() }
+      properties = {y.decode('UTF-8'): properties.get(y).decode('UTF-8') for y in properties.keys()}
       logger.trace(f"[Device Scan] found device: {host} added, IP address: {socket.inet_ntoa(info.addresses[0])}")
       logger.trace(f'info: {info}')
       logger.trace(f'properties: {properties}')
       logger.trace('')
       self.queue.put(Device(host, socket.inet_ntoa(info.addresses[0])))
 
-  def remove_service(self, *args, **kwargs):
+  def remove_service(self, *arg, **kwargs):
     pass
 
-  def update_service(self, *args, **kwargs):
+  def update_service(self, *arg, **kwargs):
     pass
 
 
 class Device:
   def __init__(self, host=None, wifi_ip=None, fw_type=None, info=None):
     self.host = host
-    self.friendly_host = host.replace('.local','')
+    self.friendly_host = host.replace('.local', '')
     self.wifi_ip = wifi_ip
     self.fw_type = fw_type
     self.info = info
@@ -205,11 +218,22 @@ class Device:
     self.version = main.version
     self.local_file = main.local_file
     self.force_flash = False
+    self.stock_model = None
+    self.fw_version = None
+    self.fw_type_str = None
+    self.app = None
+    self.model = None
+    self.color_mode = None
+    self.device_id = None
+    self.device_name = None
+    self.flash_fw_version = '0.0.0'
+    self.flash_fw_type_str = None
+    self.download_url = None
 
   def is_host_reachable(self, host, is_flashing=False):
     # check if host is reachable
-    hostcheck = re.search(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', host)
-    self.host = f'{host}.local' if '.local' not in host and not hostcheck else host
+    host_check = re.search(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', host)
+    self.host = f'{host}.local' if '.local' not in host and not host_check else host
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(3)
     if not self.wifi_ip:
@@ -218,7 +242,7 @@ class Device:
         ipaddress.IPv4Address(host)
         test_host = host
         self.host = host
-      except ipaddress.AddressValueError as err:
+      except ipaddress.AddressValueError:
         test_host = self.host
     else:
       test_host = self.wifi_ip
@@ -247,9 +271,9 @@ class Device:
         status_check = requests.get(f'http://{self.wifi_ip}/status', timeout=10)
         if status_check.status_code == 200:
           status = json.loads(status_check.content)
-          if status.get('status','') != '':
+          if status.get('status', '') != '':
             self.info = None
-            return None
+            return self.info
           fw_info = requests.get(f'http://{self.wifi_ip}/settings', timeout=3)
           self.fw_type = "stock"
           device_url = f'http://{self.wifi_ip}/settings'
@@ -267,21 +291,16 @@ class Device:
     if not info:
       logger.debug(f"Could not get info from device: {self.host}")
     self.info = info
-    return info
+    return self.info
 
   def is_homekit(self):
-    if self.fw_type == 'homekit':
-      return True
-    else:
-      return False
+    return self.fw_type == 'homekit'
 
   def is_stock(self):
-    if self.fw_type == 'stock':
-      return True
-    else:
-      return False
+    return self.fw_type == 'stock'
 
-  def parse_stock_version(self, version):
+  @staticmethod
+  def parse_stock_version(version):
     # stock can be '20201124-092159/v1.9.0@57ac4ad8', we need '1.9.0'
     # stock can be '20201124-092159/v1.9.5-DM2_autocheck', we need '1.9.5-DM2'
     # stock can be '20210107-122133/1.9_GU10_RGBW@07531e29', we need '1.9'
@@ -289,7 +308,7 @@ class Device:
     # stock can be '20210226-091047/v1.10.0-rc2-89-g623b41ec0-master', we need '1.10.0-rc2'
     # stock can be '20210318-141537/v1.10.0-geba262d', we need '1.10.0'
     logger.trace(f"version: {version}")
-    v = re.search(r'/.*?(?P<ver>([0-9]+\.)([0-9]+)(\.[0-9]+)?(-[a-z0-9]*)?)(?P<rest>(@|-|_)[a-z0-9\-]*)', version, re.IGNORECASE)
+    v = re.search(r'/.*?(?P<ver>([0-9]+\.)([0-9]+)(\.[0-9]+)?(-[a-z0-9]*)?)(?P<rest>([@\-_])[a-z0-9\-]*)', version, re.IGNORECASE)
     debug_info = v.groupdict() if v is not None else v
     logger.trace(f"stock version group: {debug_info}")
     parsed_version = v.group('ver') if v is not None else '0.0.0'
@@ -299,16 +318,18 @@ class Device:
     self.flash_fw_version = version
     self.force_flash = True
 
-  def get_current_version(self, is_flashing=False): # used when flashing between formware versions.
+  def get_current_version(self, is_flashing=False):  # used when flashing between firmware versions.
+    version = None
     if not self.get_device_info(is_flashing):
       return None
-    if self.is_homekit:
+    if self.is_homekit():
       version = self.info['version']
     elif self.is_stock():
       version = self.parse_stock_version(self.info['fw'])
     return version
 
   def get_uptime(self, is_flashing=False):
+    uptime = None
     if not self.get_device_info(is_flashing):
       logger.trace(f'get_uptime: -1')
       return -1
@@ -319,49 +340,49 @@ class Device:
     logger.trace(f'get_uptime: {uptime}')
     return uptime
 
-  def shelly_model(self, type):
-    options = {'SHPLG-1' : ['ShellyPlug', 'shelly-plug'],
-               'SHPLG-S' : ['ShellyPlugS', 'shelly-plug-s'],
-               'SHPLG-U1' : ['ShellyPlugUS', 'shelly-plug-u1'],
-               'SHPLG2-1' : ['ShellyPlug', 'shelly-plug2'],
-               'SHSW-1' : ['Shelly1', 'switch1'],
-               'SHSW-PM' : ['Shelly1PM', 'switch1pm'],
-               'SHSW-L' : ['Shelly1L', 'switch1l'],
-               'SHSW-21' : ['Shelly2', 'switch'],
-               'SHSW-25' : ['Shelly25', 'switch25'],
-               'SHAIR-1' : ['ShellyAir', 'air'],
-               'SHSW-44' : ['Shelly4Pro', 'dinrelay4'],
-               'SHUNI-1' : ['ShellyUni', 'uni'],
-               'SHEM' : ['ShellyEM', 'shellyem'],
-               'SHEM-3' : ['Shelly3EM','shellyem3'],
-               'SHSEN-1' : ['ShellySensor', 'smart-sensor'],
-               'SHGS-1' : ['ShellyGas', 'gas-sensor'],
-               'SHSM-01' : ['ShellySmoke', 'smoke-sensor'],
-               'SHHT-1' : ['ShellyHT', 'ht-sensor'],
-               'SHWT-1' : ['ShellyFlood', 'water-sensor'],
-               'SHDW-1' : ['ShellyDoorWindow', 'doorwindow-sensor'],
-               'SHDW-2' : ['ShellyDoorWindow2', 'doorwindow-sensor2'],
-               'SHSPOT-1' : ['ShellySpot', 'spot'],
-               'SHCL-255' : ['ShellyColor', 'color'],
-               'SHBLB-1' : ['ShellyBulb', 'bulb'],
-               'SHCB-1' : ['ShellyColorBulb', 'color-bulb'],
-               'SHRGBW2' : ['ShellyRGBW2', 'rgbw2'],
-               'SHRGBWW-01' : ['ShellyRGBWW', 'rgbww'],
-               'SH2LED-1' : ['ShellyLED','led1'],
-               'SHDM-1' : ['ShellyDimmer', 'dimmer'],
-               'SHDM-2' : ['ShellyDimmer2', 'dimmer-l51'],
-               'SHDIMW-1' : ['ShellyDimmerW','dimmerw1'],
-               'SHVIN-1' : ['ShellyVintage', 'bulb6w'],
-               'SHBDUO-1' : ['ShellyDuo', 'bulbduo'],
-               'SHBTN-1' : ['ShellyButton1', 'wifi-button'],
-               'SHBTN-2' : ['ShellyButton2', 'wifi-button2'],
-               'SHIX3-1' : ['ShellyI3', 'ix3'],
-    }
-    return options.get(type, type)
+  @staticmethod
+  def shelly_model(stock_model):
+    options = {'SHPLG-1': ['ShellyPlug', 'shelly-plug'],
+               'SHPLG-S': ['ShellyPlugS', 'shelly-plug-s'],
+               'SHPLG-U1': ['ShellyPlugUS', 'shelly-plug-u1'],
+               'SHPLG2-1': ['ShellyPlug', 'shelly-plug2'],
+               'SHSW-1': ['Shelly1', 'switch1'],
+               'SHSW-PM': ['Shelly1PM', 'switch1pm'],
+               'SHSW-L': ['Shelly1L', 'switch1l'],
+               'SHSW-21': ['Shelly2', 'switch'],
+               'SHSW-25': ['Shelly25', 'switch25'],
+               'SHAIR-1': ['ShellyAir', 'air'],
+               'SHSW-44': ['Shelly4Pro', 'dinrelay4'],
+               'SHUNI-1': ['ShellyUni', 'uni'],
+               'SHEM': ['ShellyEM', 'shellyem'],
+               'SHEM-3': ['Shelly3EM', 'shellyem3'],
+               'SHSEN-1': ['ShellySensor', 'smart-sensor'],
+               'SHGS-1': ['ShellyGas', 'gas-sensor'],
+               'SHSM-01': ['ShellySmoke', 'smoke-sensor'],
+               'SHHT-1': ['ShellyHT', 'ht-sensor'],
+               'SHWT-1': ['ShellyFlood', 'water-sensor'],
+               'SHDW-1': ['ShellyDoorWindow', 'doorwindow-sensor'],
+               'SHDW-2': ['ShellyDoorWindow2', 'doorwindow-sensor2'],
+               'SHSPOT-1': ['ShellySpot', 'spot'],
+               'SHCL-255': ['ShellyColor', 'color'],
+               'SHBLB-1': ['ShellyBulb', 'bulb'],
+               'SHCB-1': ['ShellyColorBulb', 'color-bulb'],
+               'SHRGBW2': ['ShellyRGBW2', 'rgbw2'],
+               'SHRGBWW-01': ['ShellyRGBWW', 'rgbww'],
+               'SH2LED-1': ['ShellyLED', 'led1'],
+               'SHDM-1': ['ShellyDimmer', 'dimmer'],
+               'SHDM-2': ['ShellyDimmer2', 'dimmer-l51'],
+               'SHDIMW-1': ['ShellyDimmerW', 'dimmerw1'],
+               'SHVIN-1': ['ShellyVintage', 'bulb6w'],
+               'SHBDUO-1': ['ShellyDuo', 'bulbduo'],
+               'SHBTN-1': ['ShellyButton1', 'wifi-button'],
+               'SHBTN-2': ['ShellyButton2', 'wifi-button2'],
+               'SHIX3-1': ['ShellyI3', 'ix3']
+               }
+    return options.get(stock_model, stock_model)
 
   def parse_local_file(self):
     if os.path.exists(self.local_file) and self.local_file.endswith('.zip'):
-      local_host = socket.gethostname()
       s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
       s.connect((self.wifi_ip, 80))
       local_ip = s.getsockname()[0]
@@ -373,7 +394,7 @@ class Device:
             logger.debug(f"zipfile: {name}")
             mfile = zfile.read(name)
             manifest_file = json.loads(mfile)
-            logger.debug(f"manifest: {json.dumps(manifest_file, indent = 4)}")
+            logger.debug(f"manifest: {json.dumps(manifest_file, indent=4)}")
             break
       manifest_version = manifest_file['version']
       manifest_name = manifest_file['name']
@@ -382,23 +403,22 @@ class Device:
         self.flash_fw_type_str = "Stock"
       else:
         self.set_force_version(manifest_version)
-        self.flash_fw_type_str = "HomeKit"
       if self.is_homekit():
-        self.dlurl = 'local'
+        self.download_url = 'local'
       else:
-        self.dlurl = f'http://{local_ip}:{webserver_port}/{self.local_file}'
+        self.download_url = f'http://{local_ip}:{webserver_port}/{self.local_file}'
       if self.is_stock() and self.stock_model == 'SHRGBW2' and self.color_mode is not None:
         m_model = f"{self.app}-{self.color_mode}"
       else:
         m_model = self.app
       if m_model != manifest_name:
         self.flash_fw_version = '0.0.0'
-        self.dlurl = None
+        self.download_url = None
       return True
     else:
       logger.debug(f"File does not exist")
       self.flash_fw_version = '0.0.0'
-      self.dlurl = None
+      self.download_url = None
       return False
 
   def update_homekit(self, release_info=None):
@@ -407,8 +427,8 @@ class Device:
     if not self.version:
       for i in release_info:
         if self.variant and self.variant not in i[1]['version']:
-          self.flash_fw_version = 'novariant'
-          self.dlurl = None
+          self.flash_fw_version = 'no_variant'
+          self.download_url = None
           return
         if self.variant:
           re_search = r'-*'
@@ -416,11 +436,11 @@ class Device:
           re_search = i[0]
         if re.search(re_search, self.fw_version):
           self.flash_fw_version = i[1]['version']
-          self.dlurl = i[1]['urls'][self.model] if self.model in i[1]['urls'] else None
+          self.download_url = i[1]['urls'][self.model] if self.model in i[1]['urls'] else None
           break
     else:
       self.flash_fw_version = self.version
-      self.dlurl = f'http://rojer.me/files/shelly/{self.version}/shelly-homekit-{self.model}.zip'
+      self.download_url = f'http://rojer.me/files/shelly/{self.version}/shelly-homekit-{self.model}.zip'
 
   def update_stock(self, release_info=None):
     self.flash_fw_type_str = 'Stock'
@@ -429,20 +449,21 @@ class Device:
       stock_model_info = release_info['data'][self.stock_model] if self.stock_model in release_info['data'] else None
       if self.variant == 'beta':
         self.flash_fw_version = self.parse_stock_version(stock_model_info['beta_ver']) if 'beta_ver' in stock_model_info else self.parse_stock_version(stock_model_info['version'])
-        self.dlurl = stock_model_info['beta_url'] if 'beta_ver' in stock_model_info else stock_model_info['url']
+        self.download_url = stock_model_info['beta_url'] if 'beta_ver' in stock_model_info else stock_model_info['url']
       else:
         try:
           self.flash_fw_version = self.parse_stock_version(stock_model_info['version']) if 'version' in stock_model_info else self.parse_stock_version(stock_model_info['beta_url'])
-          self.dlurl = stock_model_info['url']
+          self.download_url = stock_model_info['url']
         except Exception:
           self.flash_fw_version = '0.0.0'
-          self.dlurl = None
+          self.download_url = None
     else:
       self.flash_fw_version = self.version
-      self.dlurl = f'http://archive.shelly-tools.de/version/v{self.version}/{self.stock_model}.zip'
-    if self.stock_model  == 'SHRGBW2':
-      if self.dlurl and not self.version and self.color_mode and not self.local_file:
-        self.dlurl = self.dlurl.replace('.zip',f'-{self.color_mode}.zip')
+      self.download_url = f'http://archive.shelly-tools.de/version/v{self.version}/{self.stock_model}.zip'
+    if self.stock_model == 'SHRGBW2':
+      if self.download_url and not self.version and self.color_mode and not self.local_file:
+        self.download_url = self.download_url.replace('.zip', f'-{self.color_mode}.zip')
+
 
 class HomeKitDevice(Device):
   def get_info(self):
@@ -461,15 +482,15 @@ class HomeKitDevice(Device):
   def flash_firmware(self):
     if self.local_file:
       logger.debug(f"Local file: {self.local_file}")
-      myfile = open(self.local_file,'rb')
+      my_file = open(self.local_file, 'rb')
       logger.info("Now Flashing...")
-      files = {'file': ('shelly-flash.zip', myfile)}
+      files = {'file': ('shelly-flash.zip', my_file)}
     else:
       logger.info("Downloading Firmware...")
-      logger.debug(f"Remote Download URL: {self.dlurl}")
-      myfile = requests.get(self.dlurl)
+      logger.debug(f"Remote Download URL: {self.download_url}")
+      my_file = requests.get(self.download_url)
       logger.info("Now Flashing...")
-      files = {'file': ('shelly-flash.zip', myfile.content)}
+      files = {'file': ('shelly-flash.zip', my_file.content)}
     logger.debug(f"requests.post('http://{self.wifi_ip}/update', files=files")
     response = requests.post(f'http://{self.wifi_ip}/update', files=files)
     logger.debug(response.text)
@@ -479,6 +500,7 @@ class HomeKitDevice(Device):
     logger.debug(f"requests.post(url={f'http://{self.wifi_ip}/rpc/SyS.Reboot'}")
     response = requests.get(url=f'http://{self.wifi_ip}/rpc/SyS.Reboot')
     logger.trace(response.text)
+
 
 class StockDevice(Device):
   def get_info(self):
@@ -496,22 +518,24 @@ class StockDevice(Device):
 
   def flash_firmware(self):
     logger.info("Now Flashing...")
-    dlurl = self.dlurl.replace('https', 'http')
+    response = None
+    download_url = self.download_url.replace('https', 'http')
     if self.local_file:
       logger.debug(f"Local file: {self.local_file}")
-      logger.debug(f"Local Download URL: {dlurl}")
+      logger.debug(f"Local Download URL: {download_url}")
     else:
-      logger.debug(f"Remote Download URL: {dlurl}")
+      logger.debug(f"Remote Download URL: {download_url}")
     if self.fw_version == '0.0.0':
       logger.debug(f"http://{self.wifi_ip}/ota?update=true")
       response = requests.get(f'http://{self.wifi_ip}/ota?update=true')
     else:
-      logger.debug(f"http://{self.wifi_ip}/ota?url={dlurl}")
+      logger.debug(f"http://{self.wifi_ip}/ota?url={download_url}")
       try:
-        response = requests.get(f'http://{self.wifi_ip}/ota?url={dlurl}')
+        response = requests.get(f'http://{self.wifi_ip}/ota?url={download_url}')
       except Exception:
         logger.info(f"flash failed")
-    logger.trace(response.text)
+    if response:
+      logger.trace(response.text)
 
   def preform_reboot(self):
     logger.info(f"Rebooting...")
@@ -520,17 +544,19 @@ class StockDevice(Device):
     logger.trace(response.text)
 
 
-class Main():
-  def __init__(self, hosts, action, log_filename, dry_run, quiet_run, silent_run, mode, flashmode, info_level, fw_type_filter, model_type_filter, exclude, version, variant,
+class Main:
+  def __init__(self, hosts, run_action, log_filename, dry_run, quiet_run, silent_run, mode, flash_mode, info_level, fw_type_filter, model_type_filter, exclude, version, variant,
                hap_setup_code, local_file, network_type, ipv4_ip, ipv4_mask, ipv4_gw, ipv4_dns):
+    self.zc = None
+    self.listener = None
     self.hosts = hosts
-    self.action = action
+    self.run_action = run_action
     self.log_filename = log_filename
     self.dry_run = dry_run
     self.quiet_run = quiet_run
     self.silent_run = silent_run
     self.mode = mode
-    self.flashmode = flashmode
+    self.flash_mode = flash_mode
     self.info_level = info_level
     self.fw_type_filter = fw_type_filter
     self.model_type_filter = model_type_filter
@@ -545,7 +571,8 @@ class Main():
     self.ipv4_gw = ipv4_gw
     self.ipv4_dns = ipv4_dns
 
-  def get_release_info(self, info_type):
+  @staticmethod
+  def get_release_info(info_type):
     release_info = False
     release_info_url = homekit_info_url if info_type == 'homekit' else stock_info_url
     try:
@@ -555,7 +582,7 @@ class Main():
         release_info = json.loads(fp.content)
     except requests.exceptions.RequestException as err:
       logger.critical(f"{RED}CRITICAL:{NC} {err}")
-    logger.trace(f"{info_type} release_info: {json.dumps(release_info, indent = 4)}")
+    logger.trace(f"{info_type} release_info: {json.dumps(release_info, indent=4)}")
     if not release_info:
       logger.error("")
       logger.error(f"{RED}Failed to lookup online stock firmware information{NC}")
@@ -563,7 +590,8 @@ class Main():
       logger.error("https://github.com/mongoose-os-apps/shelly-homekit/wiki/Flashing#script-fails-to-run")
     return release_info
 
-  def parse_version(self, vs):
+  @staticmethod
+  def parse_version(vs):
     # 1.9.2 / 1.9
     # 1.9.3-rc3 / 2.7.0-beta1 / 2.7.0-latest / 1.9.5-DM2
     logger.trace(f"vs: {vs}")
@@ -575,28 +603,28 @@ class Main():
       minor = int(v.group('minor'))
       patch = int(v.group('patch')) if v.group('patch') is not None else 0
       variant = v.group('prerelease')
-      varSeq = int(v.group('prerelease_seq')) if v.group('prerelease_seq') and v.group('prerelease_seq').isdigit() else 0
+      var_seq = int(v.group('prerelease_seq')) if v.group('prerelease_seq') and v.group('prerelease_seq').isdigit() else 0
     except Exception:
       major = 0
       minor = 0
       patch = 0
       variant = ''
-      varSeq = 0
-    return (major, minor, patch, variant, varSeq)
+      var_seq = 0
+    return major, minor, patch, variant, var_seq
 
   def is_newer(self, v1, v2):
     vi1 = self.parse_version(v1)
     vi2 = self.parse_version(v2)
-    if (vi1[0] != vi2[0]):
-      return (vi1[0] > vi2[0])
-    elif (vi1[1] != vi2[1]):
-      return (vi1[1] > vi2[1])
-    elif (vi1[2] != vi2[2]):
-      return (vi1[2] > vi2[2])
-    elif (vi1[3] != vi2[3]):
+    if vi1[0] != vi2[0]:
+      return vi1[0] > vi2[0]
+    elif vi1[1] != vi2[1]:
+      return vi1[1] > vi2[1]
+    elif vi1[2] != vi2[2]:
+      return vi1[2] > vi2[2]
+    elif vi1[3] != vi2[3]:
       return True
-    elif (vi1[4] != vi2[4]):
-      return (vi1[4] > vi2[4])
+    elif vi1[4] != vi2[4]:
+      return vi1[4] > vi2[4]
     else:
       return False
 
@@ -605,13 +633,13 @@ class Main():
     wifi_ip = device_info.wifi_ip
     if device_info.is_homekit():
       if self.network_type == 'static':
-        message = f"Configuring static IP to {self.ipv4_ip}..."
-        value={'config': {'wifi': {'sta': {'ip': self.ipv4_ip, 'netmask': self.ipv4_mask, 'gw': self.ipv4_gw, 'nameserver': self.ipv4_dns}}}}
+        log_message = f"Configuring static IP to {self.ipv4_ip}..."
+        value = {'config': {'wifi': {'sta': {'ip': self.ipv4_ip, 'netmask': self.ipv4_mask, 'gw': self.ipv4_gw, 'nameserver': self.ipv4_dns}}}}
       else:
-        message = f"Configuring IP to use DHCP..."
-        value={'config': {'wifi': {'sta': {'ip': ''}}}}
+        log_message = f"Configuring IP to use DHCP..."
+        value = {'config': {'wifi': {'sta': {'ip': ''}}}}
       config_set_url = f'http://{wifi_ip}/rpc/Config.Set'
-      logger.info(message)
+      logger.info(log_message)
       logger.debug(f"requests.post(url={config_set_url}, json={value}")
       response = requests.post(url=config_set_url, json=value)
       logger.trace(response.text)
@@ -622,12 +650,12 @@ class Main():
         logger.trace(response.text)
     else:
       if self.network_type == 'static':
-        message = f"Configuring static IP to {self.ipv4_ip}..."
+        log_message = f"Configuring static IP to {self.ipv4_ip}..."
         config_set_url = f'http://{wifi_ip}/settings/sta?ipv4_method=static&ip={self.ipv4_ip}&netmask={self.ipv4_mask}&gateway={self.ipv4_gw}&dns={self.ipv4_dns}'
       else:
-        message = f"Configuring IP to use DHCP..."
+        log_message = f"Configuring IP to use DHCP..."
         config_set_url = f'http://{wifi_ip}/settings/sta?ipv4_method=dhcp'
-      logger.info(message)
+      logger.info(log_message)
       logger.debug(f"requests.post(url={config_set_url}")
       response = requests.post(url=config_set_url)
       logger.trace(response.text)
@@ -635,23 +663,24 @@ class Main():
 
   def write_hap_setup_code(self, wifi_ip):
     logger.info("Configuring HomeKit setup code...")
-    value={'code': self.hap_setup_code}
+    value = {'code': self.hap_setup_code}
     logger.debug(f"requests.post(url='http://{wifi_ip}/rpc/HAP.Setup', json={value}")
     response = requests.post(url=f'http://{wifi_ip}/rpc/HAP.Setup', json={'code': self.hap_setup_code})
     logger.trace(response.text)
     if response.text.startswith('null'):
       logger.info(f"Done.")
 
-  def wait_for_reboot(self, device_info, preboot_uptime=-1, reboot_only=False):
+  @staticmethod
+  def wait_for_reboot(device_info, before_reboot_uptime=-1, reboot_only=False):
     logger.debug(f"{PURPLE}[Wait For Reboot]{NC}")
     logger.info(f"waiting for {device_info.friendly_host} to reboot[!n]")
     logger.trace("")
     get_current_version = None
-    time.sleep(1) # wait for time check to fall behind
+    time.sleep(1)  # wait for time check to fall behind
     current_uptime = device_info.get_uptime(True)
     n = 1
-    if reboot_only == False:
-      while current_uptime > preboot_uptime and n < 60 or get_current_version == None:
+    if not reboot_only:
+      while current_uptime > before_reboot_uptime and n < 60 or get_current_version is None:
         logger.info(f".[!n]")
         if n == 20:
           logger.info("")
@@ -659,7 +688,7 @@ class Main():
         elif n == 40:
           logger.info("")
           logger.info(f"we'll wait just a little longer for {device_info.friendly_host} to reboot[!n]")
-        time.sleep(1) # wait 1 second before retrying.
+        time.sleep(1)  # wait 1 second before retrying.
         current_uptime = device_info.get_uptime(True)
         get_current_version = device_info.get_current_version(is_flashing=True)
         logger.debug("")
@@ -668,20 +697,19 @@ class Main():
         logger.trace(f"loop number: {n}")
     else:
       while device_info.get_uptime(True) < 3:
-        time.sleep(1) # wait 1 second before retrying.
+        time.sleep(1)  # wait 1 second before retrying.
     logger.info("")
     return get_current_version
 
   def write_flash(self, device_info):
     logger.debug(f"{PURPLE}[Write Flash]{NC}")
-    flashed = False
     uptime = device_info.get_uptime(True)
     device_info.flash_firmware()
     reboot_check = self.parse_version(self.wait_for_reboot(device_info, uptime))
-    flashfw = self.parse_version(device_info.flash_fw_version)
-    if reboot_check == flashfw:
+    flash_fw = self.parse_version(device_info.flash_fw_version)
+    if reboot_check == flash_fw:
       global flashed_devices
-      flashed_devices +=1
+      flashed_devices += 1
       logger.critical(f"{GREEN}Successfully flashed {device_info.friendly_host} to {device_info.flash_fw_version}{NC}")
     else:
       if device_info.stock_model == 'SHRGBW2':
@@ -698,10 +726,10 @@ class Main():
         logger.info(f"{RED}Flash may have failed, please manually check version{NC}")
       else:
         global failed_flashed_devices
-        failed_flashed_devices +=1
+        failed_flashed_devices += 1
         logger.info(f"{RED}Failed to flash {device_info.friendly_host} to {device_info.flash_fw_version}{NC}")
       logger.debug(f"Current: {reboot_check}")
-      logger.debug(f"flash_fw_version: {flashfw}")
+      logger.debug(f"flash_fw_version: {flash_fw}")
 
   def reboot_device(self, device_info):
     logger.debug(f"{PURPLE}[Reboot Device]{NC}")
@@ -714,12 +742,12 @@ class Main():
     logger.debug(f"{PURPLE}[Parse Info]{NC}")
     logger.trace(f"device_info: {device_info}")
 
-    global total_devices
+    global total_devices, flash_question
     total_devices += 1
 
     perform_flash = False
-    flash = False
-    durl_request = False
+    flash_question = None
+    download_url_request = False
     host = device_info.host
     friendly_host = device_info.friendly_host
     device_name = device_info.device_name
@@ -734,12 +762,13 @@ class Main():
     flash_fw_type_str = device_info.flash_fw_type_str
     force_version = device_info.version
     force_flash = device_info.force_flash
-    dlurl = device_info.dlurl
+    download_url = device_info.download_url
     wifi_ip = device_info.wifi_ip
     wifi_ssid = device_info.info.get('wifi_ssid', None) if device_info.is_homekit() else device_info.info.get('status', {}).get('wifi_sta', {}).get('ssid', None)
     wifi_rssi = device_info.info.get('wifi_rssi', None) if device_info.is_homekit() else device_info.info.get('status', {}).get('wifi_sta', {}).get('rssi', None)
     sys_temp = device_info.info.get('sys_temp', None)
-    uptime = datetime.timedelta(seconds=device_info.info.get('uptime', 0)) if device_info.is_homekit() else datetime.timedelta(seconds=device_info.info.get('status', {}).get('uptime',0))
+    uptime = datetime.timedelta(seconds=device_info.info.get('uptime', 0)) if device_info.is_homekit() else datetime.timedelta(
+      seconds=device_info.info.get('status', {}).get('uptime', 0))
     hap_ip_conns_pending = device_info.info.get('hap_ip_conns_pending', None)
     hap_ip_conns_active = device_info.info.get('hap_ip_conns_active', None)
     hap_ip_conns_max = device_info.info.get('hap_ip_conns_max', None)
@@ -749,7 +778,7 @@ class Main():
       flash_fw_version = force_version
       force_flash = device_info.force_flash
 
-    logger.debug(f"flash mode: {self.flashmode}")
+    logger.debug(f"flash mode: {self.flash_mode}")
     logger.debug(f"requires_upgrade: {requires_upgrade}")
     logger.debug(f"stock_model: {stock_model}")
     logger.debug(f"color_mode: {color_mode}")
@@ -757,31 +786,31 @@ class Main():
     logger.debug(f"flash_fw_version: {flash_fw_type_str} {flash_fw_version}")
     logger.debug(f"force_flash: {force_flash}")
     logger.debug(f"force_version: {force_version}")
-    logger.debug(f"dlurl: {dlurl}")
+    logger.debug(f"download_url: {download_url}")
 
-    if dlurl and dlurl != 'local':
-      durl_request = requests.head(dlurl)
-      logger.debug(f"durl_request: {durl_request}")
-    if flash_fw_version == 'novariant':
+    if download_url and download_url != 'local':
+      download_url_request = requests.head(download_url)
+      logger.debug(f"download_url_request: {download_url_request}")
+    if flash_fw_version == 'no_variant':
       flash_fw_type_str = f"{RED}{flash_fw_type_str}{NC}"
       latest_fw_label = f"{RED}No {device_info.variant} available{NC}"
       flash_fw_version = '0.0.0'
-      dlurl = None
-    elif not dlurl and device_info.local_file:
+      download_url = None
+    elif not download_url and device_info.local_file:
       flash_fw_type_str = f"{RED}{flash_fw_type_str}{NC}"
-      latest_fw_label = f"{RED}Invailid file{NC}"
+      latest_fw_label = f"{RED}Invalid file{NC}"
       flash_fw_version = '0.0.0'
-      dlurl = None
-    elif not dlurl or (durl_request is not False and (durl_request.status_code != 200 or durl_request.headers.get('Content-Type', '') != 'application/zip')):
+      download_url = None
+    elif not download_url or (download_url_request is not False and (download_url_request.status_code != 200 or download_url_request.headers.get('Content-Type', '') != 'application/zip')):
       flash_fw_type_str = f"{RED}{flash_fw_type_str}{NC}"
       latest_fw_label = f"{RED}Not available{NC}"
       flash_fw_version = '0.0.0'
-      dlurl = None
+      download_url = None
     else:
       latest_fw_label = flash_fw_version
 
-    flashfw_newer = self.is_newer(flash_fw_version, current_fw_version)
-    if (not self.quiet_run or (self.quiet_run and (flashfw_newer or (force_flash and flash_fw_version != '0.0.0')))) and requires_upgrade != 'Done':
+    flash_fw_newer = self.is_newer(flash_fw_version, current_fw_version)
+    if (not self.quiet_run or (self.quiet_run and (flash_fw_newer or (force_flash and flash_fw_version != '0.0.0')))) and requires_upgrade != 'Done':
       logger.info(f"")
       logger.info(f"{WHITE}Host: {NC}http://{host}")
       if int(self.info_level) > 1 or device_name != friendly_host:
@@ -801,47 +830,47 @@ class Main():
           if int(hap_ip_conns_pending) > 0:
             hap_ip_conns_pending = f"{RED}{hap_ip_conns_pending}{NC}"
           logger.info(f"{WHITE}HAP Connections: {NC}{hap_ip_conns_pending} / {hap_ip_conns_active} / {hap_ip_conns_max}{NC}")
-      if current_fw_type == self.flashmode and (current_fw_version == flash_fw_version or flash_fw_version == '0.0.0'):
+      if current_fw_type == self.flash_mode and (current_fw_version == flash_fw_version or flash_fw_version == '0.0.0'):
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version} {GREEN}\u2714{NC}")
-      elif current_fw_type == self.flashmode and flashfw_newer:
+      elif current_fw_type == self.flash_mode and flash_fw_newer:
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version} \u279c {YELLOW}{latest_fw_label}{NC}")
-      elif current_fw_type != self.flashmode and current_fw_version != flash_fw_version:
+      elif current_fw_type != self.flash_mode and current_fw_version != flash_fw_version:
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version} \u279c {YELLOW}{flash_fw_type_str} {latest_fw_label}{NC}")
-      elif current_fw_type == self.flashmode and current_fw_version != flash_fw_version:
+      elif current_fw_type == self.flash_mode and current_fw_version != flash_fw_version:
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version}")
       else:
         print("I DON'T THINK THIS IS NEEDED")
         logger.info(f"{WHITE}Firmware: {NC}{current_fw_type_str} {current_fw_version} {flash_fw_type_str} {latest_fw_label}{NC}")
 
-    if dlurl and (force_flash or requires_upgrade == True or (current_fw_type != self.flashmode) or (current_fw_type == self.flashmode and flashfw_newer)):
+    if download_url and (force_flash or requires_upgrade is True or (current_fw_type != self.flash_mode) or (current_fw_type == self.flash_mode and flash_fw_newer)):
       global upgradeable_devices
       upgradeable_devices += 1
 
-    if self.action == 'flash':
-      message = "Would have been"
+    if self.run_action == 'flash':
+      action_message = "Would have been"
       keyword = None
-      if dlurl:
+      if download_url:
         if self.exclude and friendly_host in self.exclude:
           logger.info("Skipping as device has been excluded...")
           logger.info("")
           return 0
-        elif requires_upgrade == True:
+        elif requires_upgrade is True:
           perform_flash = True
-          if self.flashmode == 'stock':
+          if self.flash_mode == 'stock':
             keyword = f"upgraded to version {flash_fw_version}"
-          elif self.flashmode == 'homekit':
-            message = "This device needs to be"
+          elif self.flash_mode == 'homekit':
+            action_message = "This device needs to be"
             keyword = "upgraded to latest stock firmware version, before you can flash to HomeKit"
         elif force_flash:
           perform_flash = True
           keyword = f"flashed to {flash_fw_type_str} version {flash_fw_version}"
-        elif current_fw_type != self.flashmode:
+        elif current_fw_type != self.flash_mode:
           perform_flash = True
           keyword = f"converted to {flash_fw_type_str} firmware"
-        elif current_fw_type == self.flashmode and flashfw_newer:
+        elif current_fw_type == self.flash_mode and flash_fw_newer:
           perform_flash = True
           keyword = f"upgraded from {current_fw_version} to version {flash_fw_version}"
-      elif not dlurl:
+      elif not download_url:
         if force_version:
           keyword = f"Version {force_version} is not available..."
         elif device_info.local_file:
@@ -851,65 +880,65 @@ class Main():
         return 0
 
       logger.debug(f"perform_flash: {perform_flash}")
-      if perform_flash == True and self.dry_run == False and self.silent_run == False:
-        if requires_upgrade == True:
-          flash_message = f"{message} {keyword}"
+      if perform_flash is True and self.dry_run is False and self.silent_run is False:
+        if requires_upgrade is True:
+          flash_message = f"{action_message} {keyword}"
         elif requires_upgrade == 'Done':
-          flash_message = f"Do you wish to contintue to flash {friendly_host} to HomeKit firmware version {flash_fw_version}"
+          flash_message = f"Do you wish to continue to flash {friendly_host} to HomeKit firmware version {flash_fw_version}"
         else:
           flash_message = f"Do you wish to flash {friendly_host} to {flash_fw_type_str} firmware version {flash_fw_version}"
-        if input(f"{flash_message} (y/n) ? ") in ('y', 'Y'):
-          flash = True
+        if flash_question is None and input(f"{flash_message} (y/n) ? ") in ('y', 'Y'):
+          flash_question = True
         else:
-          flash = False
+          flash_question = False
           logger.info("Skipping Flash...")
-      elif perform_flash == True and self.dry_run == False and self.silent_run == True:
-        flash = True
-      elif perform_flash == True and self.dry_run == True:
-        logger.info(f"{message} {keyword}...")
-      if flash == True:
+      elif perform_flash is True and self.dry_run is False and self.silent_run is True:
+        flash_question = True
+      elif perform_flash is True and self.dry_run is True:
+        logger.info(f"{action_message} {keyword}...")
+      if flash_question is True:
         self.write_flash(device_info)
       if device_info.is_homekit() and self.hap_setup_code:
         self.write_hap_setup_code(device_info.wifi_ip)
       if self.network_type:
         if self.network_type == 'static':
-          message = f"Do you wish to set your IP address to {self.ipv4_ip}"
+          action_message = f"Do you wish to set your IP address to {self.ipv4_ip}"
         else:
-          message = f"Do you wish to set your IP address to use DHCP"
-        if input(f"{message} (y/n) ? ") in ('y', 'Y'):
+          action_message = f"Do you wish to set your IP address to use DHCP"
+        if input(f"{action_message} (y/n) ? ") in ('y', 'Y'):
           set_ip = True
         else:
           set_ip = False
         if set_ip or self.silent_run:
           self.write_network_type(device_info)
-    elif self.action == 'reboot':
+    elif self.run_action == 'reboot':
       reboot = False
-      if self.dry_run == False and self.silent_run == False:
+      if self.dry_run is False and self.silent_run is False:
         if input(f"Do you wish to reboot {friendly_host} (y/n) ? ") in ('y', 'Y'):
           reboot = True
-      elif self.silent_run == True:
+      elif self.silent_run is True:
         reboot = True
-      elif self.dry_run == True:
+      elif self.dry_run is True:
         logger.info(f"Would have been rebooted...")
-      if reboot == True:
+      if reboot is True:
         self.reboot_device(device_info)
 
   def probe_device(self, device):
     logger.debug("")
     logger.debug(f"{PURPLE}[Probe Device]{NC}")
-    logger.trace(f"device_info: {json.dumps(device, indent = 4)}")
+    logger.trace(f"device_info: {json.dumps(device, indent=4)}")
 
-    global stock_release_info, homekit_release_info, tried_to_get_remote_homekit, tried_to_get_remote_stock, http_server_started, webserver_port, server, thread
+    global stock_release_info, homekit_release_info, tried_to_get_remote_homekit, tried_to_get_remote_stock, http_server_started, webserver_port, server, thread, flash_question
     requires_upgrade = False
     got_info = False
 
     if self.mode == 'keep':
-      self.flashmode = device['fw_type']
+      self.flash_mode = device['fw_type']
     else:
-      self.flashmode = self.mode
+      self.flash_mode = self.mode
     if device['fw_type'] == 'homekit':
       device_info = HomeKitDevice(device['host'], device['wifi_ip'], device['fw_type'], device['info'])
-    elif device['fw_type'] == 'stock':
+    else:
       device_info = StockDevice(device['host'], device['wifi_ip'], device['fw_type'], device['info'])
     if not device_info.get_info():
       logger.warning("")
@@ -940,7 +969,7 @@ class Main():
               tried_to_get_remote_stock = True
             if stock_release_info:
               device_info.update_stock(stock_release_info)
-              if (device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version)):
+              if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
                 requires_upgrade = True
                 got_info = True
               else:
@@ -951,7 +980,7 @@ class Main():
         else:
           got_info = True
       else:
-        if device_info.is_stock() and self.flashmode == 'homekit':
+        if device_info.is_stock() and self.flash_mode == 'homekit':
           if not stock_release_info and not tried_to_get_remote_stock:
             stock_release_info = self.get_release_info('stock')
             tried_to_get_remote_stock = True
@@ -960,20 +989,20 @@ class Main():
             tried_to_get_remote_homekit = True
           if stock_release_info and homekit_release_info:
             device_info.update_stock(stock_release_info)
-            if (device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version)):
+            if device_info.fw_version == '0.0.0' or self.is_newer(device_info.flash_fw_version, device_info.fw_version):
               requires_upgrade = True
               got_info = True
             else:
               device_info.update_homekit(homekit_release_info)
               got_info = True
-        elif self.flashmode == 'homekit':
+        elif self.flash_mode == 'homekit':
           if not homekit_release_info and not tried_to_get_remote_homekit and not self.local_file:
             homekit_release_info = self.get_release_info('homekit')
             tried_to_get_remote_homekit = True
           if homekit_release_info:
             device_info.update_homekit(homekit_release_info)
             got_info = True
-        elif self.flashmode == 'stock':
+        elif self.flash_mode == 'stock':
           if not stock_release_info and not tried_to_get_remote_stock:
             stock_release_info = self.get_release_info('stock')
             tried_to_get_remote_stock = True
@@ -987,15 +1016,15 @@ class Main():
         logger.error("")
       elif got_info:
         self.parse_info(device_info, requires_upgrade)
-        if requires_upgrade and self.action == 'flash':
-          time.sleep(10) # need to allow time for previous flash reboot to fully boot.
+        if requires_upgrade and self.run_action == 'flash' and flash_question is True:
+          time.sleep(10)  # need to allow time for previous flash reboot to fully boot.
           requires_upgrade = 'Done'
           device_info.get_info()
           if device_info.flash_fw_version != '0.0.0' and not self.is_newer(device_info.flash_fw_version, device_info.fw_version):
             if self.local_file:
               device_info.parse_local_file()
             else:
-              device_info.update_to_homekit(homekit_release_info)
+              device_info.update_homekit(homekit_release_info)
             self.parse_info(device_info, requires_upgrade)
 
   def stop_scan(self):
@@ -1008,7 +1037,7 @@ class Main():
 
   def results(self):
     logger.info(f"")
-    if self.action == 'flash':
+    if self.run_action == 'flash':
       logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices} Flashed: {flashed_devices} Failed: {failed_flashed_devices}{NC}")
     else:
       logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices}{NC}")
@@ -1030,8 +1059,8 @@ class Main():
       logger.debug(f"{PURPLE}[Device Scan] automatic scan{NC}")
       logger.info(f"{WHITE}Scanning for Shelly devices...{NC}")
       self.zc = zeroconf.Zeroconf()
-      self.listener = MyListener()
-      browser = zeroconf.ServiceBrowser(self.zc, '_http._tcp.local.', self.listener)
+      self.listener = ServiceListener()
+      zeroconf.ServiceBrowser(zc=self.zc, type_='_http._tcp.local.', listener=self.listener)
       total_devices = 0
       while True:
         try:
@@ -1047,6 +1076,7 @@ class Main():
             device = {'host': device_info.host, 'wifi_ip': device_info.wifi_ip, 'fw_type': device_info.fw_type, 'info': device_info.info}
             self.probe_device(device)
 
+
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description='Shelly HomeKit flashing script utility')
   parser.add_argument('-m', '--mode', action="store", choices=['homekit', 'keep', 'revert'], default="homekit", help="Script mode.")
@@ -1059,7 +1089,7 @@ if __name__ == '__main__':
   parser.add_argument('-e', '--exclude', action="store", dest="exclude", nargs='*', help="Exclude hosts from found devices.")
   parser.add_argument('-n', '--assume-no', action="store_true", dest='dry_run', default=False, help="Do a dummy run through.")
   parser.add_argument('-y', '--assume-yes', action="store_true", dest='silent_run', default=False, help="Do not ask any confirmation to perform the flash.")
-  parser.add_argument('-V', '--version',type=str, action="store", dest="version", default=False, help="Force a particular version.")
+  parser.add_argument('-V', '--version', type=str, action="store", dest="version", default=False, help="Force a particular version.")
   parser.add_argument('--variant', action="store", dest="variant", default=False, help="Prerelease variant name.")
   parser.add_argument('--local-file', action="store", dest="local_file", default=False, help="Use local file to flash.")
   parser.add_argument('-c', '--hap-setup-code', action="store", dest="hap_setup_code", default=False, help="Configure HomeKit setup code, after flashing.")
@@ -1169,15 +1199,15 @@ if __name__ == '__main__':
       if not args.ipv4_ip:
         message = f"{WHITE}Invalid option --ip can not be empty.{NC}"
   elif args.version and len(args.version.split('.')) < 3:
-    message = f"{WHITE}Incorect version formatting i.e '1.9.0'{NC}"
+    message = f"{WHITE}Incorrect version formatting i.e '1.9.0'{NC}"
 
   if message:
     logger.info(message)
     parser.print_help()
     sys.exit(1)
 
-  main = Main(args.hosts, action, args.log_filename, args.dry_run, args.quiet_run, args.silent_run, args.mode, None, args.info_level, args.fw_type_filter, args.model_type_filter, args.exclude, args.version, args.variant,
-              args.hap_setup_code, args.local_file, args.network_type, args.ipv4_ip, args.ipv4_mask, args.ipv4_gw, args.ipv4_dns)
+  main = Main(args.hosts, action, args.log_filename, args.dry_run, args.quiet_run, args.silent_run, args.mode, None, args.info_level, args.fw_type_filter, args.model_type_filter,
+              args.exclude, args.version, args.variant, args.hap_setup_code, args.local_file, args.network_type, args.ipv4_ip, args.ipv4_mask, args.ipv4_gw, args.ipv4_dns)
   atexit.register(main.results)
   try:
     main.device_scan()
@@ -1189,9 +1219,11 @@ if __name__ == '__main__':
     traceback.print_exception(exc_type, exc_value, exc_traceback, file=sys.stdout)
     logger.info(f'{NC}')
   except KeyboardInterrupt:
-    main.stop_scan
+    main.stop_scan()
 
-  if http_server_started and server:
+  if http_server_started and server is not None:
     logger.trace("Shutting down webserver")
+    # noinspection PyUnresolvedReferences
     server.shutdown()
+    # noinspection PyUnresolvedReferences
     thread.join()

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -718,6 +718,8 @@ class Main:
     if args.verbose >= 4:
       args.info_level = 3
     if args.log_filename:
+      args.verbose = 5
+      args.info_level = 3
       fh = MFileHandler(args.log_filename, mode='w', encoding='UTF-8')
       fh.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(lineno)d %(message)s'))
       fh.setLevel(log_level[args.verbose])

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1027,12 +1027,13 @@ class Main:
             self.parse_info(device_info, requires_upgrade)
 
   def stop_scan(self):
-    while True:
-      try:
-        self.listener.queue.get_nowait()
-      except queue.Empty:
-        self.zc.close()
-        break
+    if self.listener is not None:
+      while True:
+        try:
+          self.listener.queue.get_nowait()
+        except queue.Empty:
+          self.zc.close()
+          break
 
   def results(self):
     logger.info(f"")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -701,12 +701,12 @@ class Main:
     logger.debug(f"{PURPLE}[Wait For Reboot]{NC}")
     logger.info(f"waiting for {device_info.friendly_host} to reboot[!n]")
     logger.trace("")
-    get_current_version = None
+    current_version = None
     time.sleep(1)  # wait for time check to fall behind
     current_uptime = device_info.get_uptime(True)
     n = 1
     if not reboot_only:
-      while current_uptime > before_reboot_uptime and n < 60 or get_current_version is None:
+      while current_uptime > before_reboot_uptime and n < 60 or current_version is None:
         logger.info(f".[!n]")
         if n == 20:
           logger.info("")
@@ -716,16 +716,16 @@ class Main:
           logger.info(f"we'll wait just a little longer for {device_info.friendly_host} to reboot[!n]")
         time.sleep(1)  # wait 1 second before retrying.
         current_uptime = device_info.get_uptime(True)
-        get_current_version = device_info.get_current_version(no_error_message=True)
+        current_version = device_info.get_current_version(no_error_message=True)
         logger.debug("")
-        logger.debug(f"get_current_version: {get_current_version}")
+        logger.debug(f"current_version: {current_version}")
         n += 1
         logger.trace(f"loop number: {n}")
     else:
       while device_info.get_uptime(True) < 3:
         time.sleep(1)  # wait 1 second before retrying.
     logger.info("")
-    return get_current_version
+    return current_version
 
   def write_flash(self, device_info):
     logger.debug(f"{PURPLE}[Write Flash]{NC}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -93,9 +93,9 @@ import re
 import socket
 import subprocess
 import sys
-import traceback
 import threading
 import time
+import traceback
 import zipfile
 
 
@@ -133,12 +133,12 @@ logging.Logger.trace = functools.partialmethod(logging.Logger.log, logging.TRACE
 logging.trace = functools.partial(logging.log, logging.TRACE)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.TRACE)
-log_level = {'0': logging.CRITICAL,
-             '1': logging.ERROR,
-             '2': logging.WARNING,
-             '3': logging.INFO,
-             '4': logging.DEBUG,
-             '5': logging.TRACE}
+log_level = {0: logging.CRITICAL,
+             1: logging.ERROR,
+             2: logging.WARNING,
+             3: logging.INFO,
+             4: logging.DEBUG,
+             5: logging.TRACE}
 
 webserver_port = 8381
 http_server_started = False

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -372,6 +372,7 @@ class Device:
                'SHWT-1': ['ShellyFlood', 'water-sensor'],
                'SHDW-1': ['ShellyDoorWindow', 'doorwindow-sensor'],
                'SHDW-2': ['ShellyDoorWindow2', 'doorwindow-sensor2'],
+               'SHMOS-01': ['ShellyMotion', 'motion-sensor'],
                'SHSPOT-1': ['ShellySpot', 'spot'],
                'SHCL-255': ['ShellyColor', 'color'],
                'SHBLB-1': ['ShellyBulb', 'bulb'],
@@ -388,7 +389,7 @@ class Device:
                'SHBTN-2': ['ShellyButton2', 'wifi-button2'],
                'SHIX3-1': ['ShellyI3', 'ix3']
                }
-    return options.get(stock_model, stock_model)
+    return options.get(stock_model, [stock_model, stock_model])
 
   def parse_local_file(self):
     if os.path.exists(self.local_file) and self.local_file.endswith('.zip'):

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -960,6 +960,8 @@ class Main:
       if reboot_check == '0.0.0':
         logger.info(f"{RED}Flash may have failed, please manually check version{NC}")
       else:
+        global failed_flashed_devices
+        failed_flashed_devices += 1
         logger.info(f"{RED}Failed to flash {device_info.friendly_host} to {device_info.flash_fw_type_str} {device_info.flash_fw_version}{NC}")
       logger.debug(f"Current: {reboot_check}")
       logger.debug(f"flash_fw_version: {flash_fw}")

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1431,8 +1431,8 @@ class Main:
       logger.debug(f"")
       logger.debug(f"{PURPLE}[Device Scan] action queue entry{NC}")
       if device_info.info:
-        fw_model = device_info.info.get('model') if 'homekit' == device_info.info.get('fw_type') else device_info.shelly_model(device_info.info.get('device').get('type'))[0]
-        if (device_info.info.get('fw_type') in self.fw_type_filter or self.fw_type_filter == 'all') and self.is_model_type(fw_model) and self.is_device_name(device_info.info.get('device_name')):
+        fw_model = device_info.info.get('model') if device_info.is_homekit() else device_info.shelly_model(device_info.info.get('device').get('type'))[0]
+        if self.is_fw_type(device_info.info.get('fw_type')) and self.is_model_type(fw_model) and self.is_device_name(device_info.info.get('device_name')):
           device = {'host': device_info.host, 'wifi_ip': device_info.wifi_ip, 'fw_type': device_info.info.get('fw_type'), 'info': device_info.info}
           self.probe_device(device)
 

--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -1228,7 +1228,10 @@ class Main:
   def exit_app(self):
     logger.info(f"")
     if self.run_action == 'flash':
-      logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices} Flashed: {flashed_devices} Failed: {failed_flashed_devices}{NC}")
+      if failed_flashed_devices > 0:
+        logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices} Flashed: {flashed_devices}{NC} {RED}Failed: {failed_flashed_devices}{NC}")
+      else:
+        logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices} Flashed: {flashed_devices}{NC}")
     else:
       logger.info(f"{GREEN}Devices found: {total_devices} Upgradeable: {upgradeable_devices}{NC}")
     if self.log_filename:


### PR DESCRIPTION
- move run block into Main class, move config, device_scan, manual_hosts into own functions, better handling of webserver shutdown.
- add support for RGBW2 (both stock color modes).
- add support for ShellyMotion (list info only, must use manual IP's and use --timeout 240, as motion needs longer to wake and be detected)
- add -dn | --device-name filter to limit scan to include term.
- add '-f | --flash', '--app-version', '--timeout'
- add battery info for those devices that support it.
- python formatting and cleanup, more optimisations
- add regex literal to re.search lines, suggestion by juanfal thanks. fixes #589
- fix keyboard interrupt for manual hosts.
- if device on stock, but not on latest version, nolonger show latest shock version info, but HomeKit version available.
