### PR TITLE
Rework HSV to RGB calculation

### DIFF
--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -24,8 +24,6 @@
 
 #include "mgos_hap_accessory.hpp"
 
-#include <math.h>
-
 namespace shelly {
 namespace hap {
 
@@ -145,50 +143,51 @@ void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
   if (s == 0.0) {
     // if saturation is zero than all rgb hannels same as brightness
     r = g = b = v;
-  } else {
-    int i = static_cast<int>(h * 6);
-    float f = (h * 6.0f - i);
-    float p = v * (1.0f - s);
-    float q = v * (1.0f - f * s);
-    float t = v * (1.0f - (1.0f - f) * s);
+    return;
+  }
 
-    switch (i % 6) {
-      case 0:
-        r = v;
-        g = t;
-        b = p;
-        break;
+  int i = static_cast<int>(h * 6);
+  float f = (h * 6.0f - i);
+  float p = v * (1.0f - s);
+  float q = v * (1.0f - f * s);
+  float t = v * (1.0f - (1.0f - f) * s);
 
-      case 1:
-        r = q;
-        g = v;
-        b = p;
-        break;
+  switch (i % 6) {
+    case 0:
+      r = v;
+      g = t;
+      b = p;
+      break;
 
-      case 2:
-        r = p;
-        g = v;
-        b = t;
-        break;
+    case 1:
+      r = q;
+      g = v;
+      b = p;
+      break;
 
-      case 3:
-        r = p;
-        g = q;
-        b = v;
-        break;
+    case 2:
+      r = p;
+      g = v;
+      b = t;
+      break;
 
-      case 4:
-        r = t;
-        g = p;
-        b = v;
-        break;
+    case 3:
+      r = p;
+      g = q;
+      b = v;
+      break;
 
-      case 5:
-        r = v;
-        g = p;
-        b = q;
-        break;
-    }
+    case 4:
+      r = t;
+      g = p;
+      b = v;
+      break;
+
+    case 5:
+      r = v;
+      g = p;
+      b = q;
+      break;
   }
 }
 

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -140,7 +140,7 @@ Status RGB::Init() {
 
 void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g, float &b) {
   if (s == 0.0) {
-    // if saturation is zero than all rgb hannels same as brightness
+    // if saturation is zero than all rgb channels same as brightness
     r = g = b = v;
     return;
   }

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -138,7 +138,8 @@ Status RGB::Init() {
   return Status::OK();
 }
 
-void RGB::HSVtoRGB(float &h, float &s, float &v, float &r, float &g, float &b) {
+void RGB::HSVtoRGB(float h, float s, float v,
+                   float &r, float &g, float &b) const {
   if (s == 0.0) {
     r = g = b = 1.0;
   }

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -146,36 +146,48 @@ void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
     // if saturation is zero than all rgb hannels same as brightness
     r = g = b = v;
   } else {
-    float h1 = fmod(h, 360.0f);  // jail it to 0-359°
+    float h1 = fmod(h, 360.0f);  // jail hue into 0-359°
     float c = v * s;
     float h2 = h1 / 60.0f;
     float x = c * (1.0f - fmod(h2, 2.0f) - 1.0f);
     float m = v - c;
 
-    if (h1 < 60.0f) {
-      r = c;
-      g = x;
-      b = 0;
-    } else if (h1 < 120.0f) {
-      r = x;
-      g = c;
-      b = 0;
-    } else if (h1 < 180.0f) {
-      r = 0;
-      g = c;
-      b = x;
-    } else if (h1 < 240.0f) {
-      r = 0;
-      g = x;
-      b = c;
-    } else if (h1 < 300.0f) {
-      r = x;
-      g = 0;
-      b = c;
-    } else if (h1 < 360.0f) {
-      r = c;
-      g = 0;
-      b = x;
+    switch (static_cast<int>(h2)) {
+      case 0:
+        r = c;
+        g = x;
+        b = 0;
+        break;
+
+      case 1:
+        r = x;
+        g = c;
+        b = 0;
+        break;
+
+      case 2:
+        r = 0;
+        g = c;
+        b = x;
+        break;
+
+      case 3:
+        r = 0;
+        g = x;
+        b = c;
+        break;
+
+      case 4:
+        r = x;
+        g = 0;
+        b = c;
+        break;
+
+      case 5:
+        r = c;
+        g = 0;
+        b = x;
+        break;
     }
 
     r += m;
@@ -189,19 +201,19 @@ void RGB::SetOutputState(const char *source) {
       ("state: %s, brightness: %i, hue: %i, saturation: %i", OnOff(cfg_->state),
        cfg_->brightness, cfg_->hue, cfg_->saturation));
 
-  float h = cfg_->hue / 360.0;
-  float s = cfg_->saturation / 100.0;
-  float v = 1;  // use 1 as value, real value will be done by pwm duty
+  float h = cfg_->hue;
+  float s = cfg_->saturation / 100.0f;
+  float v = cfg_->brightness / 100.0f;
 
   float r = 0, g = 0, b = 0;
 
   HSVtoRGB(h, s, v, r, g, b);
 
-  float brv = cfg_->state ? (cfg_->brightness / 100.0) : 0;
+  int on = cfg_->state != 0 ? 1 : 0;
 
-  out_r_->SetStatePWM(r * brv, source);
-  out_g_->SetStatePWM(g * brv, source);
-  out_b_->SetStatePWM(b * brv, source);
+  out_r_->SetStatePWM(r * on, source);
+  out_g_->SetStatePWM(g * on, source);
+  out_b_->SetStatePWM(b * on, source);
 
   if (cfg_->state && cfg_->auto_off) {
     auto_off_timer_.Reset(cfg_->auto_off_delay * 1000, 0);

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -146,53 +146,49 @@ void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
     // if saturation is zero than all rgb hannels same as brightness
     r = g = b = v;
   } else {
-    float h1 = fmod(h, 360.0f);  // jail hue into 0-359°
-    float c = v * s;
-    float h2 = h1 / 60.0f;
-    float x = c * (1.0f - fmod(h2, 2.0f) - 1.0f);
-    float m = v - c;
+    int i = static_cast<int>(h * 6);
+    float f = (h * 6.0f - i);
+    float p = v * (1.0f - s);
+    float q = v * (1.0f - f * s);
+    float t = v * (1.0f - (1.0f - f) * s);
 
-    switch (static_cast<int>(h2)) {
+    switch (i % 6) {
       case 0:
-        r = c;
-        g = x;
-        b = 0;
+        r = v;
+        g = t;
+        b = p;
         break;
 
       case 1:
-        r = x;
-        g = c;
-        b = 0;
+        r = q;
+        g = v;
+        b = p;
         break;
 
       case 2:
-        r = 0;
-        g = c;
-        b = x;
+        r = p;
+        g = v;
+        b = t;
         break;
 
       case 3:
-        r = 0;
-        g = x;
-        b = c;
+        r = p;
+        g = q;
+        b = v;
         break;
 
       case 4:
-        r = x;
-        g = 0;
-        b = c;
+        r = t;
+        g = p;
+        b = v;
         break;
 
       case 5:
-        r = c;
-        g = 0;
-        b = x;
+        r = v;
+        g = p;
+        b = q;
         break;
     }
-
-    r += m;
-    g += m;
-    b += m;
   }
 }
 
@@ -201,7 +197,7 @@ void RGB::SetOutputState(const char *source) {
       ("state: %s, brightness: %i, hue: %i, saturation: %i", OnOff(cfg_->state),
        cfg_->brightness, cfg_->hue, cfg_->saturation));
 
-  float h = cfg_->hue;
+  float h = cfg_->hue / 360.0f;
   float s = cfg_->saturation / 100.0f;
   float v = cfg_->brightness / 100.0f;
 
@@ -209,7 +205,7 @@ void RGB::SetOutputState(const char *source) {
 
   HSVtoRGB(h, s, v, r, g, b);
 
-  int on = cfg_->state != 0 ? 1 : 0;
+  int on = cfg_->state ? 1 : 0;
 
   out_r_->SetStatePWM(r * on, source);
   out_g_->SetStatePWM(g * on, source);

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -141,46 +141,44 @@ Status RGB::Init() {
 void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
                    float &b) const {
   if (s == 0.0) {
-    r = g = b = 1.0;
-  }
+    // if saturation is zero than all rgb hannels same as brightness
+    r = g = b = v;
+  } else {
+    float h1 = fmod(h, 360.0f);  // jail it to 0-359°
+    float c = v * s;
+    float h2 = h1 / 60.0f;
+    float x = c * (1.0f - fmod(h2, 2.0f) - 1.0f);
+    float m = v - c;
 
-  int i = int(h * 6.0);
-  float f = (h * 6.0) - i;
-  float p = v * (1.0 - s);
-  float q = v * (1.0 - s * f);
-  float t = v * (1.0 - s * (1.0 - f));
+    if (h1 < 60.0f) {
+      r = c;
+      g = x;
+      b = 0;
+    } else if (h1 < 120.0f) {
+      r = x;
+      g = c;
+      b = 0;
+    } else if (h1 < 180.0f) {
+      r = 0;
+      g = c;
+      b = x;
+    } else if (h1 < 240.0f) {
+      r = 0;
+      g = x;
+      b = c;
+    } else if (h1 < 300.0f) {
+      r = x;
+      g = 0;
+      b = c;
+    } else if (h1 < 360.0f) {
+      r = c;
+      g = 0;
+      b = x;
+    }
 
-  switch (i % 6) {
-    case 0:
-      r = v;
-      g = t;
-      b = p;
-      break;
-    case 1:
-      r = q;
-      g = v;
-      b = p;
-      break;
-    case 2:
-      r = p;
-      g = v;
-      b = t;
-      break;
-    case 3:
-      r = p;
-      g = q;
-      b = v;
-      break;
-    case 4:
-      r = t;
-      g = p;
-      b = v;
-      break;
-    case 5:
-      r = v;
-      g = p;
-      b = q;
-      break;
+    r += m;
+    g += m;
+    b += m;
   }
 }
 

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -138,8 +138,8 @@ Status RGB::Init() {
   return Status::OK();
 }
 
-void RGB::HSVtoRGB(float h, float s, float v,
-                   float &r, float &g, float &b) const {
+void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
+                   float &b) const {
   if (s == 0.0) {
     r = g = b = 1.0;
   }

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -24,6 +24,8 @@
 
 #include "mgos_hap_accessory.hpp"
 
+#include <math.h>
+
 namespace shelly {
 namespace hap {
 

--- a/src/shelly_hap_rgb.cpp
+++ b/src/shelly_hap_rgb.cpp
@@ -138,8 +138,7 @@ Status RGB::Init() {
   return Status::OK();
 }
 
-void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g,
-                   float &b) const {
+void RGB::HSVtoRGB(float h, float s, float v, float &r, float &g, float &b) {
   if (s == 0.0) {
     // if saturation is zero than all rgb hannels same as brightness
     r = g = b = v;

--- a/src/shelly_hap_rgb.hpp
+++ b/src/shelly_hap_rgb.hpp
@@ -42,7 +42,7 @@ class RGB : public Component, public mgos::hap::Service {
   Status Init() override;
   void SetOutputState(const char *source);
   void SaveState();
-  void HSVtoRGB(float &h, float &s, float &v, float &r, float &g, float &b);
+  void HSVtoRGB(float h, float s, float v, float &r, float &g, float &b) const;
   StatusOr<std::string> GetInfo() const override;
   StatusOr<std::string> GetInfoJSON() const override;
   Status SetConfig(const std::string &config_json,

--- a/src/shelly_hap_rgb.hpp
+++ b/src/shelly_hap_rgb.hpp
@@ -42,7 +42,7 @@ class RGB : public Component, public mgos::hap::Service {
   Status Init() override;
   void SetOutputState(const char *source);
   void SaveState();
-  void HSVtoRGB(float h, float s, float v, float &r, float &g, float &b) const;
+  static void HSVtoRGB(float h, float s, float v, float &r, float &g, float &b);
   StatusOr<std::string> GetInfo() const override;
   StatusOr<std::string> GetInfoJSON() const override;
   Status SetConfig(const std::string &config_json,


### PR DESCRIPTION
Incoming h, s, v values should not be used as a reference. References should only be used if method will change them like out-params. There is no performance advantage in this case, because float = 32bit and references are also 32bit. Incoming parameters (larger than 32bit) should use "const 'datatype' &".

The method doesn't change class members, in this case the method should be const.

I also fixed the HSV to RGB calculation, it wasn't working correct

HSV input = H (0-359) S (0-1) V (0-1)
RGB output = R (0-1) G (0-1) B (0-1)

I think it would also be better to declare structs for RGB and HSV values to improve performance. I didn't change that, because there is already a class named RGB in use. In future it should be possible to make a smooth animated transition between 2 colors. In this case this conversion function will be called very often.

Example:
struct HSV { float h; float s; float v; };
struct RGB { float r; float g; float b; };
RGB HSVtoRGB(const HSV &hsv) const;