### PR TITLE
remove rounding issue hack

### DIFF
--- a/src/shelly_output.cpp
+++ b/src/shelly_output.cpp
@@ -66,7 +66,7 @@ Status OutputPin::SetState(bool on, const char *source) {
 }
 
 Status OutputPin::SetStatePWM(float duty, const char *source) {
-  if (duty > 0.000001) {  // fix rounding issue
+  if (duty != 0) {
     mgos_pwm_set(pin_, 400, duty);
     LOG(LL_INFO, ("Output %d: %f (%s)", id(), duty, source));
   } else {


### PR DESCRIPTION
Thanks to @jobl1978 this hack is no longer needed.

Before:
```
52069217 shelly_hap_rgb.cpp:194  state: on, brightness: 1, hue: 120, saturation: 100
52073495 shelly_output.cpp:74    Output 1: OFF (HAP)
52078227 shelly_output.cpp:71    Output 2: 0.010000 (HAP)
52082336 shelly_output.cpp:74    Output 3: 0.000000 (HAP) # real value was something like 0.0000001
```

After:
```
52069217 shelly_hap_rgb.cpp:194  state: on, brightness: 1, hue: 120, saturation: 100
52073495 shelly_output.cpp:74    Output 1: OFF (HAP)
52078227 shelly_output.cpp:71    Output 2: 0.010000 (HAP)
52082336 shelly_output.cpp:74    Output 3: OFF (HAP)
```