### PR TITLE
Rework OTA verification

### DIFF
--- a/src/Shelly1/shelly_init.cpp
+++ b/src/Shelly1/shelly_init.cpp
@@ -22,6 +22,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/Shelly1/shelly_init.cpp
+++ b/src/Shelly1/shelly_init.cpp
@@ -22,7 +22,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"switch1"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/Shelly1L/shelly_init.cpp
+++ b/src/Shelly1L/shelly_init.cpp
@@ -24,6 +24,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/Shelly1L/shelly_init.cpp
+++ b/src/Shelly1L/shelly_init.cpp
@@ -24,7 +24,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"switch1l"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/Shelly1PM/shelly_init.cpp
+++ b/src/Shelly1PM/shelly_init.cpp
@@ -23,6 +23,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/Shelly1PM/shelly_init.cpp
+++ b/src/Shelly1PM/shelly_init.cpp
@@ -23,7 +23,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"switch1pm"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/Shelly2/shelly_init.cpp
+++ b/src/Shelly2/shelly_init.cpp
@@ -23,7 +23,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"switch"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/Shelly2/shelly_init.cpp
+++ b/src/Shelly2/shelly_init.cpp
@@ -23,6 +23,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/Shelly25/shelly_init_peripherals.cpp
+++ b/src/Shelly25/shelly_init_peripherals.cpp
@@ -25,6 +25,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 static struct mgos_ade7953 *s_ade7953 = NULL;
 
 static Status PowerMeterInit(std::vector<std::unique_ptr<PowerMeter>> *pms) {

--- a/src/Shelly25/shelly_init_peripherals.cpp
+++ b/src/Shelly25/shelly_init_peripherals.cpp
@@ -25,7 +25,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"switch25"};
 
 static struct mgos_ade7953 *s_ade7953 = NULL;
 

--- a/src/ShellyI3/shelly_init.cpp
+++ b/src/ShellyI3/shelly_init.cpp
@@ -23,7 +23,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"ix3"};
 
 // i3 inputs are super noisy and cause interrupt storm.
 // Instead we run a frequent hardware timer that smoothes things out.

--- a/src/ShellyI3/shelly_init.cpp
+++ b/src/ShellyI3/shelly_init.cpp
@@ -23,6 +23,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 // i3 inputs are super noisy and cause interrupt storm.
 // Instead we run a frequent hardware timer that smoothes things out.
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,

--- a/src/ShellyPlug/shelly_init.cpp
+++ b/src/ShellyPlug/shelly_init.cpp
@@ -22,7 +22,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"shelly-plug2"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyPlug/shelly_init.cpp
+++ b/src/ShellyPlug/shelly_init.cpp
@@ -22,6 +22,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/ShellyPlugS/shelly_init.cpp
+++ b/src/ShellyPlugS/shelly_init.cpp
@@ -22,6 +22,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 static OutputPin *s_led_out = nullptr;
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,

--- a/src/ShellyPlugS/shelly_init.cpp
+++ b/src/ShellyPlugS/shelly_init.cpp
@@ -22,7 +22,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"shelly-plug-s"};
 
 static OutputPin *s_led_out = nullptr;
 

--- a/src/ShellyRGBW2/shelly_init.cpp
+++ b/src/ShellyRGBW2/shelly_init.cpp
@@ -22,6 +22,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/ShellyRGBW2/shelly_init.cpp
+++ b/src/ShellyRGBW2/shelly_init.cpp
@@ -22,7 +22,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"rgbw2", "rgbww"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyRGBW2/shelly_init.cpp
+++ b/src/ShellyRGBW2/shelly_init.cpp
@@ -22,7 +22,8 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"rgbw2", "rgbww"};
+const std::set<std::string> g_compatibleFirmwareNames{"rgbw2", "rgbw2-color",
+                                                      "rgbw2-white"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyU/shelly_init.cpp
+++ b/src/ShellyU/shelly_init.cpp
@@ -27,6 +27,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/ShellyU/shelly_init.cpp
+++ b/src/ShellyU/shelly_init.cpp
@@ -27,7 +27,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"shellyu"};
+const std::set<std::string> g_compatibleFirmwareNames;
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyU/shelly_init.cpp
+++ b/src/ShellyU/shelly_init.cpp
@@ -27,7 +27,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames{"shellyu"};
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyU25/shelly_init.cpp
+++ b/src/ShellyU25/shelly_init.cpp
@@ -26,7 +26,7 @@
 
 namespace shelly {
 
-const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+const std::set<std::string> g_compatibleFirmwareNames;
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,

--- a/src/ShellyU25/shelly_init.cpp
+++ b/src/ShellyU25/shelly_init.cpp
@@ -26,6 +26,8 @@
 
 namespace shelly {
 
+const std::set<std::string> g_compatibleFirmwareNames{"todo!!!"};
+
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -772,13 +772,17 @@ static void OTABeginCB(int ev, void *ev_data, void *userdata) {
     arg->result = MGOS_UPD_WAIT;
     return;
   }
+
   // Check app name.
-  if (mg_vcmp(&arg->mi.name, MGOS_APP) != 0) {
+  std::string app_name(arg->mi.name.p);
+  if (g_compatibleFirmwareNames.find(app_name) ==
+      g_compatibleFirmwareNames.end()) {
     LOG(LL_ERROR,
-        ("Wrong app name '%.*s'", (int) arg->mi.name.len, arg->mi.name.p));
+        ("Wrong app name '%.*s'", (int) app_name.length(), app_name.c_str()));
     arg->result = MGOS_UPD_ABORT;
     return;
   }
+
   // Stop the HAP server.
   if (!(s_service_flags & SHELLY_SERVICE_FLAG_UPDATE)) {
     s_wait_start = mgos_uptime();

--- a/src/shelly_main.hpp
+++ b/src/shelly_main.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "mgos_sys_config.h"
@@ -33,6 +34,7 @@
 namespace shelly {
 
 extern std::vector<std::unique_ptr<Component>> g_comps;
+extern const std::set<std::string> g_compatibleFirmwareNames;
 
 Input *FindInput(int id);
 Output *FindOutput(int id);


### PR DESCRIPTION
Reason for this rework is to prevent having 3 different RGBW2 firmwares if Shelly will do a OTA update from HomeKit back to Stock