### PR TITLE
fix sed commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,9 @@ ShellyU25: build-ShellyU25
 
 fs/index.html.gz: fs_src/index.html fs_src/style.css fs_src/script.js fs_src/logo.svg Makefile
 	cat fs_src/index.html | \
-	sed "s/.*<link.*rel=\"stylesheet\".*/<style>\n\n<\/style>/g" | sed -e '/<style>/ r fs_src/style.css' | \
-	sed "s/.*<script.*src=\"script.js\".*/<script>\n\n<\/script>/g" | sed -e '/<script>/ r fs_src/script.js' | \
-	sed -e '/.*<img.*src=".\/logo.svg".*/ {' -e 'r fs_src/logo.svg' -e 'd' -e '}' | \
-	gzip -9 -c > fs/index.html.gz
+	sed "s/.*<link.*rel=\"stylesheet\".*//g" | sed -e '/<style>/ r fs_src/style.css' | \
+	sed "s/.*<script.*src=\"script.js\".*/<script>/g" | sed -e '/<script>/ r fs_src/script.js' | \
+	sed -e '/.*<img.*src=".\/logo.svg".*/ {' -e 'r fs_src/logo.svg' -e 'd' -e '}' > fs/index.html
 
 build-%: fs/index.html.gz Makefile
 	$(MOS) build --platform=$(PLATFORM) --build-var=MODEL=$* \

--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -4,8 +4,10 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-  <!--  style.css inserted below during build -->
+  <!-- link tag will beremoved and style tag will be filled with style.css during build -->
   <link rel="stylesheet" href="style.css">
+  <style>
+  </style>
 </head>
 <body onLoad="onLoad()">
 
@@ -665,6 +667,7 @@
   </div>
 </div>
 <!-- script.js inserted below during build -->
-<script src="script.js"></script>
+<script src="script.js">
+</script>
 </body>
 </html>


### PR DESCRIPTION
some sed versions can work with newlines, whit them the first command produces
```
<style>nn</style>
```
instead of
```
<style>
</style>
```
same on the script tag

for example it happens with sed of older Mac OS versions, following stackoverflow it maybe also happens with gnu sed.