### PR TITLE
Delete AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,9 +1,0 @@
-# Shelly-HomeKit authors
-
-The following people have contributed to the project (in chronological order):
-
- * [Deomid "rojer" Ryabkov](https://github.com/rojer)
- * [Andy Blackburn](https://github.com/andyblac)
- * [Dominik Schemhaus](https://github.com/schemhad)
- * [Timothy Langer](https://github.com/ZeeVox)
- * [Timo Schilling](https://github.com/timoschilling)


### PR DESCRIPTION
Up for discussion!

I would say this file isn't needed for mainly two reasons:
1. It will come out of sync fast
2. GitHub has this nice prominante contributors section on the repo start page
<img width="388" alt="image" src="https://user-images.githubusercontent.com/165599/113956898-91f31580-981e-11eb-9495-89c13a4d63ae.png">
