### PR TITLE
Pressing up or down will always stop a moving window covering

### DIFF
--- a/src/shelly_hap_window_covering.cpp
+++ b/src/shelly_hap_window_covering.cpp
@@ -651,7 +651,7 @@ void WindowCovering::HandleInputEvent01(Direction dir, Input::Event ev,
   bool stop = false;
   bool is_toggle = (cfg_->in_mode == (int) InMode::kSeparateToggle);
   if (state) {
-    if (moving_dir_ == Direction::kNone || moving_dir_ != dir) {
+    if (moving_dir_ == Direction::kNone) {
       float pos = (dir == Direction::kOpen ? kFullyOpen : kFullyClosed);
       last_ext_move_dir_ = dir;
       SetTgtPos(pos, "ext");


### PR DESCRIPTION
Currently only a press to the same direction will stop a moving covering.

I changed the behavior in that way that pressing any direction will stop the covering if it is moving. This is the standard behavior of most covering controllers.

Should be linked to the following issue
https://github.com/mongoose-os-apps/shelly-homekit/issues/639