### PR TITLE
Reduce frequent logging during transitions

### DIFF
--- a/src/shelly_hap_light_bulb.cpp
+++ b/src/shelly_hap_light_bulb.cpp
@@ -272,6 +272,11 @@ void LightBulb::StartTransition() {
 
   LOG(LL_INFO, ("Transition started... %d [ms]", cfg_->transition_time));
 
+  LOG(LL_INFO, ("Output 1: %.2f => %.2f", rgbw_start_.r, rgbw_end_.r));
+  LOG(LL_INFO, ("Output 2: %.2f => %.2f", rgbw_start_.g, rgbw_end_.g));
+  LOG(LL_INFO, ("Output 3: %.2f => %.2f", rgbw_start_.b, rgbw_end_.b));
+  LOG(LL_INFO, ("Output 4: %.2f => %.2f", rgbw_start_.w, rgbw_end_.w));
+
   // restarting transition timer to fade
   transition_start_ = mgos_uptime_micros();
   transition_timer_.Reset(10, MGOS_TIMER_REPEAT);
@@ -426,6 +431,7 @@ void LightBulb::TransitionTimerCB() {
   if (elapsed > duration) {
     transition_timer_.Clear();
     rgbw_now_ = rgbw_end_;
+    LOG(LL_INFO, ("Transition ready"));
   } else {
     float alpha = static_cast<float>(elapsed) / static_cast<float>(duration);
     rgbw_now_.r = alpha * rgbw_end_.r + (1 - alpha) * rgbw_start_.r;

--- a/src/shelly_output.cpp
+++ b/src/shelly_output.cpp
@@ -68,10 +68,10 @@ Status OutputPin::SetState(bool on, const char *source) {
 Status OutputPin::SetStatePWM(float duty, const char *source) {
   if (duty != 0) {
     mgos_pwm_set(pin_, 400, duty);
-    LOG(LL_INFO, ("Output %d: %f (%s)", id(), duty, source));
+    LOG(LL_DEBUG, ("Output %d: %f (%s)", id(), duty, source));
   } else {
     mgos_pwm_set(pin_, 0, 0);
-    LOG(LL_INFO, ("Output %d: OFF (%s)", id(), source));
+    LOG(LL_DEBUG, ("Output %d: OFF (%s)", id(), source));
   }
   return Status::OK();
 }


### PR DESCRIPTION
Clearer to read and should also reduce lagging between timer calls a little bit.

New log output:
```
896655873 shelly_hap_light_bu:273 Transition started... 3000 [ms]
896694004 shelly_hap_light_bu:275 Output 1: 1.00 => 0.50
896730289 shelly_hap_light_bu:276 Output 2: 0.65 => 0.32
896766288 shelly_hap_light_bu:277 Output 3: 0.00 => 0.00
896810333 shelly_hap_light_bu:278 Output 4: 0.00 => 0.00
896859045 shelly_hap_light_bu:525 Brightness read 1: 50
899852427 shelly_hap_light_bu:434 Transition ready
```
