### PR TITLE
remove redundant w channel nulling

### DIFF
--- a/src/shelly_hap_light_bulb.cpp
+++ b/src/shelly_hap_light_bulb.cpp
@@ -198,9 +198,6 @@ void LightBulb::HSVtoRGBW(RGBW &rgbw) const {
     rgbw.r = rgbw.r - rgbw.w;
     rgbw.g = rgbw.g - rgbw.w;
     rgbw.b = rgbw.b - rgbw.w;
-  } else {
-    // otherwise turn white channel off
-    rgbw.w = 0.0f;
   }
 }
 


### PR DESCRIPTION
the unused w channel is already nulled here https://github.com/mongoose-os-apps/shelly-homekit/blob/master/src/ShellyRGBW2/shelly_init.cpp#L57