### PR TITLE
added support for Prometheus for output, powermanagement and temperature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += --warn-undefined-variables
 
-.PHONY: build check-format format release upload Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 Custom2
+.PHONY: build check-format format release upload Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 Custom2 Custom16
 
 MOS ?= mos
 # Build locally by default if Docker is available.
@@ -24,7 +24,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly2 Shelly25 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 ShellyU ShellyU25 Custom2
+build: Shelly1 Shelly1L Shelly1PM Shelly2 Shelly25 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 ShellyU ShellyU25 Custom2 Custom16
 
 release:
 	@[ -z "$(wildcard fs/conf*.json fs/kvs.json)" ] || { echo; echo "XXX No configs in release builds allowed"; echo; exit 1; }
@@ -68,6 +68,10 @@ ShellyU25: build-ShellyU25
 	@true
 
 Custom2: build-Custom2
+	@true
+
+Custom16: PLATFORM=esp32
+Custom16: build-Custom16
 	@true
 
 fs/index.html.gz: $(wildcard fs_src/*) Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += --warn-undefined-variables
 
-.PHONY: build check-format format release upload Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2
+.PHONY: build check-format format release upload Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 Custom2
 
 MOS ?= mos
 # Build locally by default if Docker is available.
@@ -24,7 +24,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly2 Shelly25 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 ShellyU ShellyU25
+build: Shelly1 Shelly1L Shelly1PM Shelly2 Shelly25 ShellyI3 ShellyPlug ShellyPlugS ShellyRGBW2 ShellyU ShellyU25 Custom2
 
 release:
 	@[ -z "$(wildcard fs/conf*.json fs/kvs.json)" ] || { echo; echo "XXX No configs in release builds allowed"; echo; exit 1; }
@@ -65,6 +65,9 @@ ShellyU: build-ShellyU
 
 ShellyU25: PLATFORM=ubuntu
 ShellyU25: build-ShellyU25
+	@true
+
+Custom2: build-Custom2
 	@true
 
 fs/index.html.gz: $(wildcard fs_src/*) Makefile

--- a/libreset/src/shelly_reset.cpp
+++ b/libreset/src/shelly_reset.cpp
@@ -19,6 +19,12 @@
 
 #include "mgos.hpp"
 
+#if defined(MGOS_HAVE_VFS_FS_SPIFFS) || defined(MGOS_HAVE_VFS_FS_LFS)
+extern "C" {
+#include "mgos_vfs.h"
+}
+#endif
+
 #if CS_PLATFORM == CS_P_ESP8266
 extern "C" {
 #include "user_interface.h"

--- a/mos.yml
+++ b/mos.yml
@@ -140,6 +140,7 @@ libs:
   # - location: https://github.com/mongoose-os-libs/rpc-mqtt
   - location: https://github.com/mongoose-os-libs/rpc-ws
   - location: https://github.com/mongoose-os-libs/sntp
+  - location: https://github.com/mongoose-os-libs/prometheus-metrics
 
 conds:
   - when: build_vars.MODEL == "Shelly1"

--- a/mos.yml
+++ b/mos.yml
@@ -547,4 +547,42 @@ conds:
         - ["gdo1", "gdo", {title: "GDO1 settings"}]
         - ["gdo1.name", "ShellyU25 GDO"]
 
+  - when: build_vars.MODEL == "Custom2"
+    apply:
+      name: switch
+      libs:
+        - location: https://github.com/mongoose-os-libs/mongoose
+          variant: esp8266-nossl
+      build_vars:
+        FLASH_SIZE: 2097152
+        FS_SIZE: 262144
+        BOOT_CONFIG_ADDR: 0x1000
+        MGOS_ROOT_FS_TYPE: SPIFFS
+      cdefs:
+        PRODUCT_HW_REV: '"1.0"'
+        STOCK_FW_MODEL: '"SHSW-21"'
+        MG_ENABLE_SSL: 0
+      config_schema:
+        - ["device.id", "custom21-??????"]
+        - ["shelly.name", "custom21-??????"]
+        - ["wifi.ap.ssid", "custom21-??????"]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Shelly SW1"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Shelly SSW1"]
+        - ["in1.sensor.name", "Shelly S1"]
+        - ["sw2", "sw", {title: "SW2 settings"}]
+        - ["sw2.name", "Shelly SW2"]
+        - ["in2", "in", {title: "Input 2 settings"}]
+        - ["in2.ssw.name", "Shelly SSW2"]
+        - ["in2.sensor.name", "Shelly S2"]
+        - ["gdo1", "gdo", {title: "GDO1 settings"}]
+        - ["gdo1.name", "Garage Door"]
+        # Only for backward compatibility (config <= v3).
+        - ["ssw1", "ssw", {title: "SSW1 settings"}]
+        - ["ssw1.name", "Input 1"]
+        - ["ssw2", "ssw", {title: "SSW2 settings"}]
+        - ["ssw2.name", "Input 2"]
+
+
 manifest_version: 2020-01-29

--- a/mos.yml
+++ b/mos.yml
@@ -141,6 +141,7 @@ libs:
   - location: https://github.com/mongoose-os-libs/sntp
   - location: https://github.com/mongoose-os-libs/prometheus-metrics
 
+
 conds:
   - when: build_vars.MODEL == "Shelly1"
     apply:
@@ -553,6 +554,7 @@ conds:
       libs:
         - location: https://github.com/mongoose-os-libs/mongoose
           variant: esp8266-nossl
+        - location: https://github.com/mongoose-os-libs/dash
       build_vars:
         FLASH_SIZE: 2097152
         FS_SIZE: 262144
@@ -584,5 +586,69 @@ conds:
         - ["ssw2", "ssw", {title: "SSW2 settings"}]
         - ["ssw2.name", "Input 2"]
 
+  - when: build_vars.MODEL == "Custom16"
+    apply:
+      platform: esp32
+      name: switch
+      libs:
+        - location: https://github.com/mongoose-os-libs/mongoose
+          variant: esp32
+        - location: https://github.com/mongoose-os-libs/vfs-fs-spiffs        
+        - location: https://github.com/mongoose-os-libs/dash
+      build_vars:
+        MGOS_ROOT_FS_TYPE: SPIFFS
+      cdefs:
+        PRODUCT_HW_REV: '"1.0"'
+        STOCK_FW_MODEL: '"XXX"'
+        MG_ENABLE_SSL: 0
+      config_schema:
+        - ["device.id", "custom16-??????"]
+        - ["shelly.name", "custom16-??????"]
+        - ["wifi.ap.ssid", "custom16-??????"]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Custom SW1"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Custom SSW1"]
+        - ["in1.sensor.name", "Custom S1"]
+        - ["sw2", "sw", {title: "SW2 settings"}]
+        - ["sw2.name", "Custom SW2"]
+        - ["in2", "in", {title: "Input 2 settings"}]
+        - ["in2.ssw.name", "Custom SSW2"]
+        - ["in2.sensor.name", "Custom S2"]
+        - ["sw3", "sw", {title: "SW3 settings"}]
+        - ["sw3.name", "Custom SW3"]
+        - ["in3", "in", {title: "Input 3 settings"}]
+        - ["in3.ssw.name", "Custom SSW3"]
+        - ["in3.sensor.name", "Custom S3"]
+        - ["sw4", "sw", {title: "SW4 settings"}]
+        - ["sw4.name", "Custom SW4"]
+        - ["in4", "in", {title: "Input 4 settings"}]
+        - ["in4.ssw.name", "Custom SSW4"]
+        - ["in4.sensor.name", "Custom S4"]
+        - ["sw5", "sw", {title: "SW5 settings"}]
+        - ["sw5.name", "Custom SW5"]
+        - ["in5", "in", {title: "Input 5 settings"}]
+        - ["in5.ssw.name", "Custom SSW5"]
+        - ["in5.sensor.name", "Custom S5"]
+        - ["sw6", "sw", {title: "SW6 settings"}]
+        - ["sw6.name", "Custom SW6"]
+        - ["in6", "in", {title: "Input 6 settings"}]
+        - ["in6.ssw.name", "Custom SSW6"]
+        - ["in6.sensor.name", "Custom S6"]
+        - ["sw7", "sw", {title: "SW7 settings"}]
+        - ["sw7.name", "Custom SW7"]
+        - ["in7", "in", {title: "Input 7 settings"}]
+        - ["in7.ssw.name", "Custom SSW7"]
+        - ["in7.sensor.name", "Custom S7"]
+        - ["sw8", "sw", {title: "SW8 settings"}]
+        - ["sw8.name", "Custom SW8"]
+        - ["in8", "in", {title: "Input 8 settings"}]
+        - ["in8.ssw.name", "Custom SSW8"]
+        - ["in8.sensor.name", "Custom S8"]
+        - ["sw9", "sw", {title: "SW9 settings"}]
+        - ["sw9.name", "Custom SW9"]
+        - ["in9", "in", {title: "Input 9 settings"}]
+        - ["in9.ssw.name", "Custom SSW9"]
+        - ["in9.sensor.name", "Custom S9"]
 
 manifest_version: 2020-01-29

--- a/mos.yml
+++ b/mos.yml
@@ -593,8 +593,10 @@ conds:
       libs:
         - location: https://github.com/mongoose-os-libs/mongoose
           variant: esp32
-        - location: https://github.com/mongoose-os-libs/vfs-fs-spiffs        
-        - location: https://github.com/mongoose-os-libs/dash
+        - location: https://github.com/mongoose-os-libs/i2c
+        - location: https://github.com/mongoose-os-libs/pcf857x-i2c       
+        - location: https://github.com/mongoose-os-libs/dash # optional
+        - location: https://github.com/mongoose-os-libs/rpc-service-i2c # optional, debug
       build_vars:
         MGOS_ROOT_FS_TYPE: SPIFFS
       cdefs:
@@ -602,6 +604,10 @@ conds:
         STOCK_FW_MODEL: '"XXX"'
         MG_ENABLE_SSL: 0
       config_schema:
+        - ["i2c.enable", true]
+        - ["i2c.debug", false]
+        - ["i2c.sda_gpio", 0]
+        - ["i2c.scl_gpio", 2]
         - ["device.id", "custom16-??????"]
         - ["shelly.name", "custom16-??????"]
         - ["wifi.ap.ssid", "custom16-??????"]
@@ -650,5 +656,40 @@ conds:
         - ["in9", "in", {title: "Input 9 settings"}]
         - ["in9.ssw.name", "Custom SSW9"]
         - ["in9.sensor.name", "Custom S9"]
+        - ["sw10", "sw", {title: "SW10 settings"}]
+        - ["sw10.name", "Custom SW10"]
+        - ["in10", "in", {title: "Input 10 settings"}]
+        - ["in10.ssw.name", "Custom SSW10"]
+        - ["in10.sensor.name", "Custom S10"]
+        - ["sw11", "sw", {title: "SW11 settings"}]
+        - ["sw11.name", "Custom SW11"]
+        - ["in11", "in", {title: "Input 11 settings"}]
+        - ["in11.ssw.name", "Custom SSW11"]
+        - ["in11.sensor.name", "Custom S11"]
+        - ["sw12", "sw", {title: "SW12 settings"}]
+        - ["sw12.name", "Custom SW12"]
+        - ["in12", "in", {title: "Input 12 settings"}]
+        - ["in12.ssw.name", "Custom SSW12"]
+        - ["in12.sensor.name", "Custom S12"]
+        - ["sw13", "sw", {title: "SW13 settings"}]
+        - ["sw13.name", "Custom SW13"]
+        - ["in13", "in", {title: "Input 13 settings"}]
+        - ["in13.ssw.name", "Custom SSW13"]
+        - ["in13.sensor.name", "Custom S13"]
+        - ["sw14", "sw", {title: "SW14 settings"}]
+        - ["sw14.name", "Custom SW14"]
+        - ["in14", "in", {title: "Input 14 settings"}]
+        - ["in14.ssw.name", "Custom SSW14"]
+        - ["in14.sensor.name", "Custom S14"]
+        - ["sw15", "sw", {title: "SW15 settings"}]
+        - ["sw15.name", "Custom SW15"]
+        - ["in15", "in", {title: "Input 15 settings"}]
+        - ["in15.ssw.name", "Custom SSW15"]
+        - ["in15.sensor.name", "Custom S15"]
+        - ["sw16", "sw", {title: "SW16 settings"}]
+        - ["sw16.name", "Custom SW16"]
+        - ["in16", "in", {title: "Input 16 settings"}]
+        - ["in16.ssw.name", "Custom SSW16"]
+        - ["in16.sensor.name", "Custom S16"]
 
 manifest_version: 2020-01-29

--- a/src/Custom16/custom16_pcf857x_input.cpp
+++ b/src/Custom16/custom16_pcf857x_input.cpp
@@ -1,0 +1,145 @@
+
+#include "custom16_pcf857x_input.hpp"
+
+#include "mgos.hpp"
+#include "mgos_pcf857x.h"
+
+namespace shelly {
+namespace custom16 {
+
+
+InputPCF857xPin::InputPCF857xPin(int id, struct mgos_pcf857x *d, int pin, int on_value, enum mgos_gpio_pull_type pull,
+                   bool enable_reset)
+    : InputPCF857xPin(id, d, {.pin = pin,
+                    .on_value = on_value,
+                    .pull = pull,
+                    .enable_reset = enable_reset,
+                    .short_press_duration_ms = kDefaultShortPressDurationMs,
+                    .long_press_duration_ms = kDefaultLongPressDurationMs}) {
+}
+
+InputPCF857xPin::InputPCF857xPin(int id, struct mgos_pcf857x *d, const Config &cfg)
+    : Input(id), cfg_(cfg), d_(d), timer_(std::bind(&InputPCF857xPin::HandleTimer, this)) {
+}
+
+void InputPCF857xPin::Init() {
+  mgos_pcf857x_gpio_setup_input(d_, cfg_.pin, cfg_.pull);
+  mgos_pcf857x_gpio_set_button_handler(d_, cfg_.pin, cfg_.pull, MGOS_GPIO_INT_EDGE_ANY, 20,
+                               GPIOIntHandler, this);
+  bool state = GetState();
+  LOG(LL_INFO, ("InputPCF857xPin %d: pin %d, on_value %d, state %s", id(), cfg_.pin,
+                cfg_.on_value, OnOff(state)));
+}
+
+void InputPCF857xPin::SetInvert(bool invert) {
+  invert_ = invert;
+  GetState();
+}
+
+InputPCF857xPin::~InputPCF857xPin() {
+  mgos_pcf857x_gpio_remove_int_handler(d_, cfg_.pin, nullptr, nullptr);
+}
+
+bool InputPCF857xPin::ReadPin() {
+  return mgos_pcf857x_gpio_read(d_, cfg_.pin);
+}
+
+bool InputPCF857xPin::GetState() {
+  last_state_ = (ReadPin() == cfg_.on_value) ^ invert_;
+  return last_state_;
+}
+
+// static
+void InputPCF857xPin::GPIOIntHandler(int pin, void *arg) {
+  static_cast<InputPCF857xPin *>(arg)->HandleGPIOInt();
+  (void) pin;
+}
+
+void InputPCF857xPin::DetectReset(double now, bool cur_state) {
+  if (cfg_.enable_reset && now < 30) {
+    if (now - last_change_ts_ > 5) {
+      change_cnt_ = 0;
+    }
+    change_cnt_++;
+    if (change_cnt_ >= 10) {
+      change_cnt_ = 0;
+      CallHandlers(Event::kReset, cur_state);
+    }
+  }
+}
+
+void InputPCF857xPin::HandleGPIOInt() {
+  bool last_state = last_state_;
+  bool cur_state = GetState();
+  if (cur_state == last_state) return;  // Noise
+  LOG(LL_DEBUG, ("Input %d: %s (%d), st %d", id(), OnOff(cur_state),
+                 mgos_pcf857x_gpio_read(d_, cfg_.pin), (int) state_));
+  CallHandlers(Event::kChange, cur_state);
+  double now = mgos_uptime();
+  DetectReset(now, cur_state);
+  switch (state_) {
+    case State::kIdle:
+      if (cur_state) {
+        timer_.Reset(cfg_.short_press_duration_ms, 0);
+        state_ = State::kWaitOffSingle;
+        timer_cnt_ = 0;
+      }
+      break;
+    case State::kWaitOffSingle:
+      if (!cur_state) {
+        state_ = State::kWaitOnDouble;
+      }
+      break;
+    case State::kWaitOnDouble:
+      if (cur_state) {
+        timer_.Reset(cfg_.short_press_duration_ms, 0);
+        state_ = State::kWaitOffDouble;
+        timer_cnt_ = 0;
+      }
+      break;
+    case State::kWaitOffDouble:
+      if (!cur_state) {
+        timer_.Clear();
+        CallHandlers(Event::kDouble, cur_state);
+        state_ = State::kIdle;
+      }
+      break;
+    case State::kWaitOffLong:
+      if (!cur_state) {
+        timer_.Clear();
+        if (timer_cnt_ == 1) {
+          CallHandlers(Event::kSingle, cur_state);
+        }
+        state_ = State::kIdle;
+      }
+      break;
+  }
+  last_change_ts_ = now;
+}
+
+void InputPCF857xPin::HandleTimer() {
+  timer_cnt_++;
+  bool cur_state = GetState();
+  LOG(LL_DEBUG, ("Input %d: timer, st %d", id(), (int) state_));
+  switch (state_) {
+    case State::kIdle:
+      break;
+    case State::kWaitOffSingle:
+    case State::kWaitOffDouble:
+      timer_.Reset(cfg_.long_press_duration_ms - cfg_.short_press_duration_ms,
+                   0);
+      state_ = State::kWaitOffLong;
+      break;
+    case State::kWaitOnDouble:
+      CallHandlers(Event::kSingle, cur_state);
+      state_ = State::kIdle;
+      break;
+    case State::kWaitOffLong:
+      if (timer_cnt_ == 2) {
+        CallHandlers(Event::kLong, cur_state);
+      }
+      break;
+  }
+}
+}  // namespace custom16
+}  // namespace shelly

--- a/src/Custom16/custom16_pcf857x_input.hpp
+++ b/src/Custom16/custom16_pcf857x_input.hpp
@@ -1,0 +1,75 @@
+
+#pragma once
+
+#include "shelly_common.hpp"
+#include "shelly_input.hpp"
+#include "mgos_timers.hpp"
+#include "mgos_pcf857x.h"
+
+namespace shelly {
+namespace custom16 {
+
+
+class InputPCF857xPin : public Input {
+
+public:
+ public:
+  static constexpr int kDefaultShortPressDurationMs = 500;
+  static constexpr int kDefaultLongPressDurationMs = 1000;
+
+  struct Config {
+    int pin;
+    int on_value;
+    enum mgos_gpio_pull_type pull;
+    bool enable_reset;
+    int short_press_duration_ms;
+    int long_press_duration_ms;
+  };
+
+  InputPCF857xPin(int id, struct mgos_pcf857x *d, int pin, int on_value, enum mgos_gpio_pull_type pull,
+           bool enable_reset);
+  InputPCF857xPin(int id, struct mgos_pcf857x *d, const Config &cfg);
+  virtual ~InputPCF857xPin();
+
+  // Input interface impl.
+  bool GetState() override;
+  virtual void Init() override;
+  void SetInvert(bool invert) override;
+
+ protected:
+  virtual bool ReadPin();
+  void HandleGPIOInt();
+
+  const Config cfg_;
+  bool invert_ = false;
+
+ private:
+  struct mgos_pcf857x *d_;
+
+  enum class State {
+    kIdle = 0,
+    kWaitOffSingle = 1,
+    kWaitOnDouble = 2,
+    kWaitOffDouble = 3,
+    kWaitOffLong = 4,
+  };
+
+  static void GPIOIntHandler(int pin, void *arg);
+
+  void DetectReset(double now, bool cur_state);
+
+  void HandleTimer();
+
+  bool last_state_ = false;
+  int change_cnt_ = 0;         // State change counter for reset.
+  double last_change_ts_ = 0;  // Timestamp of last change (uptime).
+
+  State state_ = State::kIdle;
+  int timer_cnt_ = 0;
+  mgos::Timer timer_;
+
+  InputPCF857xPin(const InputPCF857xPin &other) = delete;
+};
+
+}  // namespace custom16
+}  // namespace shelly

--- a/src/Custom16/custom16_pcf857x_output.cpp
+++ b/src/Custom16/custom16_pcf857x_output.cpp
@@ -1,0 +1,62 @@
+
+#include "custom16_pcf857x_output.hpp"
+
+#include "mgos.hpp"
+#include "mgos_pcf857x.h"
+
+namespace shelly {
+namespace custom16 {
+
+OutputPCF857xPin::OutputPCF857xPin(int id, struct mgos_pcf857x *d, int pin, int on_value) 
+   : Output(id),
+      d_(d),
+      pin_(pin),
+      on_value_(on_value) {
+  // TODO check d
+  //mgos_pcf857x_gpio_set_mode(d_, pin_, MGOS_GPIO_MODE_OUTPUT);
+  LOG(LL_INFO, ("OutputPCF857xPin %d: pin %d, on_value %d, state %s", id, pin,
+                on_value, OnOff(GetState())));
+}
+
+OutputPCF857xPin::~OutputPCF857xPin() {
+}
+
+bool OutputPCF857xPin::GetState() {
+  //LOG(LL_INFO, ("READ[%d]: %d, on_value: %d", pin_, mgos_pcf857x_gpio_read(d_, pin_), on_value_));
+  return (mgos_pcf857x_gpio_read(d_, pin_) && on_value_ > 0) ^ out_invert_;
+}
+
+int OutputPCF857xPin::pin() const {
+  return pin_;
+}
+
+Status OutputPCF857xPin::SetState(bool on, const char *source) {
+  bool cur_state = GetState();
+  mgos_pcf857x_gpio_write(d_, pin_, ((on ^ out_invert_) ? on_value_ : !on_value_));
+  if (on == cur_state) return Status::OK();
+  if (source == nullptr) source = "";
+  mgos_pcf857x_print_state(d_);
+  bool new_state = GetState();
+  LOG(LL_INFO,
+      ("Output %d: %s -> %s [%s] (%s)", id(), OnOff(cur_state), OnOff(on),  OnOff(new_state), source));
+  return Status::OK();
+}
+
+Status OutputPCF857xPin::SetStatePWM(float duty, const char *source) {
+  
+  return Status::OK();
+}
+
+Status OutputPCF857xPin::Pulse(bool on, int duration_ms, const char *source) {
+  
+  return Status::OK();
+}
+
+void OutputPCF857xPin::SetInvert(bool out_invert) {
+  out_invert_ = out_invert;
+  GetState();
+}
+
+
+}  // namespace custom16
+}  // namespace shelly

--- a/src/Custom16/custom16_pcf857x_output.hpp
+++ b/src/Custom16/custom16_pcf857x_output.hpp
@@ -1,0 +1,39 @@
+
+#pragma once
+
+#include "shelly_common.hpp"
+#include "shelly_output.hpp"
+#include "mgos_pcf857x.h"
+
+namespace shelly {
+namespace custom16 {
+
+
+class OutputPCF857xPin : public Output {
+
+public:
+  OutputPCF857xPin(int id, struct mgos_pcf857x *d, int pin, int on_value);
+  virtual ~OutputPCF857xPin();
+
+  // Output interface impl.
+  bool GetState() override;
+  Status SetState(bool on, const char *source) override;
+  Status SetStatePWM(float duty, const char *source) override;
+  Status Pulse(bool on, int duration_ms, const char *source) override;
+  int pin() const;
+  void SetInvert(bool out_invert) override;
+
+ protected:
+  bool out_invert_ = false;
+
+ private:
+  struct mgos_pcf857x *d_;
+
+  const int pin_;
+  const int on_value_;
+
+  OutputPCF857xPin(const OutputPCF857xPin &other) = delete;
+};
+
+}  // namespace custom16
+}  // namespace shelly

--- a/src/Custom16/shelly_init.cpp
+++ b/src/Custom16/shelly_init.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 15, 1));
+  outputs->emplace_back(new OutputPin(2, 13, 1));
+  auto *in1 = new InputPin(1, 12, 1, MGOS_GPIO_PULL_UP, true);
+  in1->AddHandler(std::bind(&HandleInputResetSequence, in1, 4, _1, _2));
+  in1->Init();
+  inputs->emplace_back(in1);
+  auto *in2 = new InputPin(2, 14, 1, MGOS_GPIO_PULL_UP, false);
+  in2->Init();
+  inputs->emplace_back(in2);
+  (void) sys_temp;
+  (void) pms;
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  
+  
+  CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(2, mgos_sys_config_get_sw2(), mgos_sys_config_get_in2(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  
+}
+
+}  // namespace shelly

--- a/src/Custom16/shelly_init.cpp
+++ b/src/Custom16/shelly_init.cpp
@@ -20,22 +20,43 @@
 #include "shelly_hap_garage_door_opener.hpp"
 #include "shelly_input_pin.hpp"
 #include "shelly_main.hpp"
+#include "custom16_pcf857x_output.hpp"
+#include "custom16_pcf857x_input.hpp"
+
+#include "mgos_pcf857x.h"
 
 namespace shelly {
+
+static bool create_failed = false;
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,
                        std::unique_ptr<TempSensor> *sys_temp) {
-  outputs->emplace_back(new OutputPin(1, 15, 1));
-  outputs->emplace_back(new OutputPin(2, 13, 1));
-  auto *in1 = new InputPin(1, 12, 1, MGOS_GPIO_PULL_UP, true);
-  in1->AddHandler(std::bind(&HandleInputResetSequence, in1, 4, _1, _2));
-  in1->Init();
-  inputs->emplace_back(in1);
-  auto *in2 = new InputPin(2, 14, 1, MGOS_GPIO_PULL_UP, false);
-  in2->Init();
-  inputs->emplace_back(in2);
+
+  struct mgos_pcf857x *dout, *din;
+
+  if (!(dout = mgos_pcf8575_create(mgos_i2c_get_global(), 0x20, -1))) {
+    LOG(LL_ERROR, ("Could not create ouptput PCF857X"));
+    create_failed = true;
+    return;
+  }
+  if (!(din = mgos_pcf8575_create(mgos_i2c_get_global(), 0x21, 14))) {
+    LOG(LL_ERROR, ("Could not create input PCF857X"));
+    create_failed = true;
+    return;
+  }
+
+  for(int i = 0; i<16; i++) {
+    outputs->emplace_back(new custom16::OutputPCF857xPin(i+1, dout, i, 1));
+    auto *in = new custom16::InputPCF857xPin(i+1, din, i, 1, MGOS_GPIO_PULL_UP, (i==0));
+    if(i==0) {
+      in->AddHandler(std::bind(&HandleInputResetSequence, in, 4, _1, _2));
+    }
+    in->Init();
+    inputs->emplace_back(in);
+  }
+
   (void) sys_temp;
   (void) pms;
 }
@@ -44,10 +65,41 @@ void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
                       std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
                       HAPAccessoryServerRef *svr) {
   
-  
+  if(create_failed) {
+    return;
+  }
+
   CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
                   comps, accs, svr, false /* to_pri_acc */);
   CreateHAPSwitch(2, mgos_sys_config_get_sw2(), mgos_sys_config_get_in2(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(3, mgos_sys_config_get_sw3(), mgos_sys_config_get_in3(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(4, mgos_sys_config_get_sw4(), mgos_sys_config_get_in4(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(5, mgos_sys_config_get_sw5(), mgos_sys_config_get_in5(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(6, mgos_sys_config_get_sw6(), mgos_sys_config_get_in6(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(7, mgos_sys_config_get_sw7(), mgos_sys_config_get_in7(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(8, mgos_sys_config_get_sw8(), mgos_sys_config_get_in8(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(9, mgos_sys_config_get_sw9(), mgos_sys_config_get_in9(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(10, mgos_sys_config_get_sw10(), mgos_sys_config_get_in10(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(11, mgos_sys_config_get_sw11(), mgos_sys_config_get_in11(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(12, mgos_sys_config_get_sw12(), mgos_sys_config_get_in12(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(13, mgos_sys_config_get_sw13(), mgos_sys_config_get_in13(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(14, mgos_sys_config_get_sw14(), mgos_sys_config_get_in14(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(15, mgos_sys_config_get_sw15(), mgos_sys_config_get_in15(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(16, mgos_sys_config_get_sw16(), mgos_sys_config_get_in16(),
                   comps, accs, svr, false /* to_pri_acc */);
   
 }

--- a/src/Custom2/shelly_init.cpp
+++ b/src/Custom2/shelly_init.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 15, 1));
+  outputs->emplace_back(new OutputPin(2, 13, 1));
+  auto *in1 = new InputPin(1, 12, 1, MGOS_GPIO_PULL_UP, true);
+  in1->AddHandler(std::bind(&HandleInputResetSequence, in1, 4, _1, _2));
+  in1->Init();
+  inputs->emplace_back(in1);
+  auto *in2 = new InputPin(2, 14, 1, MGOS_GPIO_PULL_UP, false);
+  in2->Init();
+  inputs->emplace_back(in2);
+  (void) sys_temp;
+  (void) pms;
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  // Garage door opener mode.
+  if (mgos_sys_config_get_shelly_mode() == 2) {
+    auto *gdo_cfg = (struct mgos_config_gdo *) mgos_sys_config_get_gdo1();
+    std::unique_ptr<hap::GarageDoorOpener> gdo(new hap::GarageDoorOpener(
+        1, FindInput(1), FindInput(2), FindOutput(1), FindOutput(2), gdo_cfg));
+    if (gdo == nullptr || !gdo->Init().ok()) {
+      return;
+    }
+    gdo->set_primary(true);
+    mgos::hap::Accessory *pri_acc = (*accs)[0].get();
+    pri_acc->SetCategory(kHAPAccessoryCategory_GarageDoorOpeners);
+    pri_acc->AddService(gdo.get());
+    comps->emplace_back(std::move(gdo));
+    return;
+  }
+  // Use legacy layout if upgraded from an older version (pre-2.1).
+  // However, presence of detached inputs overrides it.
+  bool compat_20 = (mgos_sys_config_get_shelly_legacy_hap_layout() &&
+                    mgos_sys_config_get_sw1_in_mode() != 3 &&
+                    mgos_sys_config_get_sw2_in_mode() != 3);
+  if (!compat_20) {
+    CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                    comps, accs, svr, false /* to_pri_acc */);
+    CreateHAPSwitch(2, mgos_sys_config_get_sw2(), mgos_sys_config_get_in2(),
+                    comps, accs, svr, false /* to_pri_acc */);
+  } else {
+    CreateHAPSwitch(2, mgos_sys_config_get_sw2(), mgos_sys_config_get_in2(),
+                    comps, accs, svr, true /* to_pri_acc */);
+    CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                    comps, accs, svr, true /* to_pri_acc */);
+    std::reverse(comps->begin(), comps->end());
+  }
+}
+
+}  // namespace shelly

--- a/src/shelly_output.cpp
+++ b/src/shelly_output.cpp
@@ -23,7 +23,25 @@
 
 namespace shelly {
 
+#if MGOS_HAVE_PROMETHEUS_METRICS
+#include "mgos_prometheus_metrics.h"
+
+static void metrics_shelly_output(struct mg_connection *nc, void *user_data) {
+  Output* out = (Output*) user_data;
+
+ mgos_prometheus_metrics_printf(
+        nc, GAUGE, "shelly_output", "Output state",
+        "{id=\"%d\"} %d", out->id(), out->GetState());
+    
+  (void) user_data;
+}
+#endif // MGOS_HAVE_PROMETHEUS_METRICS
+
+
 Output::Output(int id) : id_(id) {
+   #if MGOS_HAVE_PROMETHEUS_METRICS
+    mgos_prometheus_metrics_add_handler(metrics_shelly_output, this);
+  #endif
 }
 
 Output::~Output() {

--- a/src/shelly_temp_sensor.cpp
+++ b/src/shelly_temp_sensor.cpp
@@ -19,7 +19,29 @@
 
 namespace shelly {
 
+
+#if MGOS_HAVE_PROMETHEUS_METRICS
+#include "mgos_prometheus_metrics.h"
+
+static void metrics_shelly_temperatur(struct mg_connection *nc, void *user_data) {
+  TempSensor* sensor = (TempSensor*) user_data;
+
+  const auto &temp = sensor->GetTemperature();
+  if(temp.ok()) {
+    mgos_prometheus_metrics_printf(
+        nc, GAUGE, "shelly_temperatur", "Temperatur in (Celcius)",
+        "%f", temp.ValueOrDie());
+
+  }
+  (void) user_data;
+}
+#endif // MGOS_HAVE_PROMETHEUS_METRICS
+
+
 TempSensor::TempSensor() {
+   #if MGOS_HAVE_PROMETHEUS_METRICS
+    mgos_prometheus_metrics_add_handler(metrics_shelly_temperatur, this);
+  #endif
 }
 
 TempSensor::~TempSensor() {


### PR DESCRIPTION
I added Prometheus support to some of the shelly properties. This allows me to monitor e.g. power usage with Grafana.
This is just a quick shot, I'm not sure if you could do the callbacks as instance member functions of the C++ class. That would probably be nicer, but I'm not very familiar with C++. 
If the prometheus library is not added the specific code should not be compiled. At least that was my understanding from the prometheus-metrics library.