### PR TITLE
Bulb support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1
@@ -70,6 +70,9 @@ ShellyPlus1PM: build-ShellyPlus1PM
 	@true
 
 ShellyRGBW2: build-ShellyRGBW2
+	@true
+
+ShellyVintage: build-ShellyVintage
 	@true
 
 ShellyU: PLATFORM=ubuntu

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2 ShellyVintage
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1
@@ -47,6 +47,9 @@ Shelly2: build-Shelly2
 	@true
 
 Shelly25: build-Shelly25
+	@true
+
+ShellyColorBulb: build-ShellyColorBulb
 	@true
 
 ShellyDuo: build-ShellyDuo

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyRGBW2
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1
@@ -47,6 +47,9 @@ Shelly2: build-Shelly2
 	@true
 
 Shelly25: build-Shelly25
+	@true
+
+ShellyDuo: build-ShellyDuo
 	@true
 
 ShellyI3: build-ShellyI3

--- a/mos.yml
+++ b/mos.yml
@@ -605,6 +605,27 @@ conds:
         - ["in1.ssw.name", "Shelly SSW1"]
         - ["in1.sensor.name", "Shelly S1"]
 
+  - when: build_vars.MODEL == "ShellyVintage"
+    apply:
+      name: bulb6w # To allow OTA from stock fw.
+      libs:
+        - origin: https://github.com/mongoose-os-libs/mongoose
+          variant: esp8266-nossl
+      build_vars:
+        FLASH_SIZE: 2097152
+        FS_SIZE: 262144
+        MGOS_ROOT_FS_TYPE: SPIFFS
+      cdefs:
+        PRODUCT_HW_REV: '"1.0"'
+        STOCK_FW_MODEL: '"SHVIN-1"'
+        # We don't use SSL, HomeKit uses its own crypto. This saves ~120K.
+        MG_ENABLE_SSL: 0
+      config_schema:
+        - ["device.id", "ShellyVintage-??????"]
+        - ["shelly.name", "ShellyVintage-??????"]
+        - ["wifi.ap.ssid", "ShellyVintage-??????"]
+        - ["lb1", "lb", {title: "Light bulb settings"}]
+
   # Test device for BLE development.
   - when: build_vars.MODEL == "ShellyT32"
     apply:

--- a/mos.yml
+++ b/mos.yml
@@ -369,6 +369,31 @@ conds:
         - ["ssw2", "ssw", {title: "SSW2 settings"}]
         - ["ssw2.name", "Input 2"]
 
+  - when: build_vars.MODEL == "ShellyColorBulb"
+    apply:
+      name: color-bulb # To allow OTA from stock fw.
+      libs:
+        - origin: https://github.com/mongoose-os-libs/mongoose
+          variant: esp8266-nossl
+      build_vars:
+        FLASH_SIZE: 2097152
+        FS_SIZE: 262144
+        BOOT_CONFIG_ADDR: 0x1000  # To be compatible with stock firmware.
+        MGOS_ROOT_FS_TYPE: SPIFFS
+      cdefs:
+        PWM_SUPPORT: 1
+        PRODUCT_HW_REV: '"1.0"'
+        STOCK_FW_MODEL: '"SHCB-1"'
+        # We don't use SSL, HomeKit uses its own crypto. This saves ~120K.
+        MG_ENABLE_SSL: 0
+      config_schema:
+        - ["shelly.mode", 4] # 4 - RGBW"
+        - ["device.id", "shellycolorbulb-??????"]
+        - ["shelly.name", "shellycolorbulb-??????"]
+        - ["wifi.ap.ssid", "shellycolorbulb-??????"]
+        - ["lb1", "lb", {title: "RGBW "}]
+        - ["lb1.initial_state", 2] # no input available
+
   - when: build_vars.MODEL == "ShellyDuo"
     apply:
       name: bulbduo # To allow OTA from stock fw.

--- a/mos.yml
+++ b/mos.yml
@@ -369,6 +369,27 @@ conds:
         - ["ssw2", "ssw", {title: "SSW2 settings"}]
         - ["ssw2.name", "Input 2"]
 
+  - when: build_vars.MODEL == "ShellyDuo"
+    apply:
+      name: bulbduo # To allow OTA from stock fw.
+      libs:
+        - origin: https://github.com/mongoose-os-libs/mongoose
+          variant: esp8266-nossl
+      build_vars:
+        FLASH_SIZE: 2097152
+        FS_SIZE: 262144
+        MGOS_ROOT_FS_TYPE: SPIFFS
+      cdefs:
+        PRODUCT_HW_REV: '"1.0"'
+        STOCK_FW_MODEL: '"SHBDUO-1"'
+        # We don't use SSL, HomeKit uses its own crypto. This saves ~120K.
+        MG_ENABLE_SSL: 0
+      config_schema:
+        - ["device.id", "ShellyBulbDuo-??????"]
+        - ["shelly.name", "ShellyBulbDuo-??????"]
+        - ["wifi.ap.ssid", "ShellyBulbDuo-??????"]
+        - ["lb1", "lb", {title: "Light bulb settings"}]
+
   - when: build_vars.MODEL == "ShellyI3"
     apply:
       name: ix3

--- a/src/ShellyColorBulb/shelly_init.cpp
+++ b/src/ShellyColorBulb/shelly_init.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shelly_cct_controller.hpp"
+#include "shelly_hap_input.hpp"
+#include "shelly_hap_light_bulb.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+#include "shelly_rgbw_controller.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(UNUSED_ARG std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       UNUSED_ARG std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       UNUSED_ARG std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 13, 1));  // R
+  outputs->emplace_back(new OutputPin(2, 12, 1));  // G
+  outputs->emplace_back(new OutputPin(3, 14, 1));  // B
+  outputs->emplace_back(new OutputPin(4, 5, 1));   // W
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  std::unique_ptr<LightBulbControllerBase> lightbulb_controller;
+  std::unique_ptr<hap::LightBulb> hap_light;
+  auto *lb_cfg = (struct mgos_config_lb *) mgos_sys_config_get_lb1();
+
+  lightbulb_controller.reset(new RGBWController(
+      lb_cfg, FindOutput(1), FindOutput(2), FindOutput(3), FindOutput(4)));
+
+  hap_light.reset(new hap::LightBulb(
+      1, nullptr, std::move(lightbulb_controller), lb_cfg, false));
+
+  if (hap_light == nullptr || !hap_light->Init().ok()) {
+    return;
+  }
+
+  mgos::hap::Accessory *pri_acc = accs->front().get();
+  hap_light->set_primary(true);
+  pri_acc->SetCategory(kHAPAccessoryCategory_Lighting);
+  pri_acc->AddService(hap_light.get());
+
+  comps->push_back(std::move(hap_light));
+}
+}  // namespace shelly

--- a/src/ShellyDuo/shelly_init.cpp
+++ b/src/ShellyDuo/shelly_init.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shelly_cct_controller.hpp"
+#include "shelly_hap_input.hpp"
+#include "shelly_hap_light_bulb.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_light_bulb_controller.hpp"
+#include "shelly_main.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(UNUSED_ARG std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       UNUSED_ARG std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       UNUSED_ARG std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 5, 1));
+  outputs->emplace_back(new OutputPin(2, 4, 1));
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  std::unique_ptr<LightBulbControllerBase> lightbulb_controller;
+  std::unique_ptr<hap::LightBulb> hap_light;
+  auto *lb_cfg = (struct mgos_config_lb *) mgos_sys_config_get_lb1();
+
+  lightbulb_controller.reset(
+      new CCTController(lb_cfg, FindOutput(1), FindOutput(2)));
+
+  hap_light.reset(new hap::LightBulb(
+      1, nullptr, std::move(lightbulb_controller), lb_cfg, false));
+
+  if (hap_light == nullptr || !hap_light->Init().ok()) {
+    return;
+  }
+
+  mgos::hap::Accessory *pri_acc = accs->front().get();
+  hap_light->set_primary(true);
+  pri_acc->SetCategory(kHAPAccessoryCategory_Lighting);
+  pri_acc->AddService(hap_light.get());
+
+  comps->push_back(std::move(hap_light));
+}
+}  // namespace shelly

--- a/src/ShellyVintage/shelly_init.cpp
+++ b/src/ShellyVintage/shelly_init.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shelly_hap_input.hpp"
+#include "shelly_hap_light_bulb.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_light_bulb_controller.hpp"
+#include "shelly_main.hpp"
+#include "shelly_white_controller.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(UNUSED_ARG std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       UNUSED_ARG std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       UNUSED_ARG std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 4, 1));
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  std::unique_ptr<LightBulbControllerBase> lightbulb_controller;
+  std::unique_ptr<hap::LightBulb> hap_light;
+  auto *lb_cfg = (struct mgos_config_lb *) mgos_sys_config_get_lb1();
+
+  lightbulb_controller.reset(new WhiteController(lb_cfg, FindOutput(1)));
+
+  hap_light.reset(new hap::LightBulb(
+      1, nullptr, std::move(lightbulb_controller), lb_cfg, false));
+
+  if (hap_light == nullptr || !hap_light->Init().ok()) {
+    return;
+  }
+
+  mgos::hap::Accessory *pri_acc = accs->front().get();
+  hap_light->set_primary(true);
+  pri_acc->SetCategory(kHAPAccessoryCategory_Lighting);
+  pri_acc->AddService(hap_light.get());
+
+  comps->push_back(std::move(hap_light));
+}
+}  // namespace shelly


### PR DESCRIPTION
Add Support for Shelly Bulbs.

- [x] Duo (closes #369)
- [x] Color Bulb (closes #823)
- [x] Vintage (closes #719)
- [x] ~remove initial state input setting~ (done by #853)

I have tested this code on Duo E27, Vintage A60, Color Bulb E27 /  GU10.
Shelly Support says that the E27 and GU10 have the same pinout and all Vintages have the same pinout.