### PR TITLE
WC: Respect ramp up time when calibrating close

### DIFF
--- a/src/shelly_hap_window_covering.cpp
+++ b/src/shelly_hap_window_covering.cpp
@@ -492,7 +492,8 @@ void WindowCovering::RunOnce() {
       const float p1 = p1v.ValueOrDie();
       int move_time_ms = (mgos_uptime_micros() - begin_) / 1000;
       LOG_EVERY_N(LL_INFO, 8, ("WC %d: P1 = %.3f", id(), p1));
-      if (p1 < cfg_->idle_power_thr && move_time_ms > 1000) {
+      if (p1 < cfg_->idle_power_thr &&
+          move_time_ms > cfg_->max_ramp_up_time_ms) {
         out_close_->SetState(false, StateStr(state_));
         float move_power = p_sum_ / p_num_;
         LOG(LL_INFO, ("WC %d: calibration done, move_time %d, move_power %.3f",


### PR DESCRIPTION
The `wc.max_ramp_up_time_ms` setting defaults to 5000ms and gives time
for motors to ramp up and draw some real power before we determine
whether they're actually running (by comparing their power draw to the
`wc.idle_power_thr` setting).

When calibrating the window covering _opening_ the calibration logic
waits the whole ramp up time before determining whether the motor is
idle, but this logic is missing when calibrating the closing. There's
just a 1000ms check hard-coded but if the motor takes longer than that
to get going and draw sufficient power the calibration will be deemed
complete (too early).

This patch simply copies the ramp up check from the open calibration
logic to the close calibration logic, which I guess was just forgotten
in f41b01f5854f5.