### PR TITLE
Detached with relay control

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -472,6 +472,7 @@
               <option id="in_mode_4" value="4">Activation</option>
               <option id="in_mode_5" value="5">Edge (both inputs)</option>
               <option id="in_mode_6" value="6">Activation (both inputs)</option>
+              <option id="in_mode_7" value="7">Detached with Relay Control (Momentary)</option>
             </select>
           </div>
           <div class="form-control" id="in_inverted_container" style="display: none">

--- a/mos.yml
+++ b/mos.yml
@@ -1,6 +1,6 @@
 author: Shelly-HomeKit contributors
 description: A HomeKit firmware for Shelly switches
-version: 2.11.0-beta5
+version: 2.11.0-beta5-DetachedWithRelay
 
 libs_version: latest
 modules_version: latest

--- a/src/Shelly1/shelly_init.cpp
+++ b/src/Shelly1/shelly_init.cpp
@@ -76,7 +76,8 @@ void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
 
   // Single switch with non-detached input and no sensors = only one accessory.
   bool to_pri_acc = (sensors.empty() && (mgos_sys_config_get_sw1_in_mode() !=
-                                         (int) InMode::kDetached));
+                                         (int) InMode::kDetached) && (mgos_sys_config_get_sw1_in_mode() !=
+                                         (int) InMode::kDetachedWithRelay));
   CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
                   comps, accs, svr, to_pri_acc);
 

--- a/src/Shelly1PM/shelly_init.cpp
+++ b/src/Shelly1PM/shelly_init.cpp
@@ -91,7 +91,8 @@ void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
 
   // Single switch with non-detached input and no sensors = only one accessory.
   bool to_pri_acc = (sensors.empty() && (mgos_sys_config_get_sw1_in_mode() !=
-                                         (int) InMode::kDetached));
+                                         (int) InMode::kDetached) && (mgos_sys_config_get_sw1_in_mode() !=
+                                         (int) InMode::kDetachedWithRelay));
   CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
                   comps, accs, svr, to_pri_acc);
 

--- a/src/ShellyRGBW2/shelly_init.cpp
+++ b/src/ShellyRGBW2/shelly_init.cpp
@@ -140,7 +140,7 @@ void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
     }
     comps->push_back(std::move(hap_light));
 
-    if (lb_cfg->in_mode == (int) InMode::kDetached && first_detatched_input) {
+    if ((lb_cfg->in_mode == (int) InMode::kDetached || lb_cfg->in_mode == (int) InMode::kDetachedWithRelay )&& first_detatched_input) {
       hap::CreateHAPInput(1, mgos_sys_config_get_in1(), comps, accs, svr);
       first_detatched_input = false;
     }

--- a/src/shelly_common.hpp
+++ b/src/shelly_common.hpp
@@ -102,6 +102,7 @@ enum class InMode {
   kEdgeBoth = 5,
   kActivationBoth = 6,
 #endif
+  kDetachedWithRelay = 7,
   kMax,
 };
 

--- a/src/shelly_hap_light_bulb.cpp
+++ b/src/shelly_hap_light_bulb.cpp
@@ -335,7 +335,9 @@ Status LightBulb::SetConfig(const std::string &config_json,
   }
   if (cfg.in_mode != -2 && cfg_->in_mode != cfg.in_mode) {
     if (cfg_->in_mode == (int) InMode::kDetached ||
-        cfg.in_mode == (int) InMode::kDetached) {
+        cfg.in_mode == (int) InMode::kDetached ||
+        cfg_->in_mode == (int) InMode::kDetachedWithRelay ||
+        cfg.in_mode == (int) InMode::kDetachedWithRelay) {
       *restart_required = true;
     }
     cfg_->in_mode = cfg.in_mode;
@@ -458,6 +460,7 @@ void LightBulb::InputEventHandler(Input::Event ev, bool state) {
     case Input::Event::kChange: {
       switch (static_cast<InMode>(cfg_->in_mode)) {
         case InMode::kMomentary:
+        case InMode::kDetachedWithRelay:
           if (state) {  // Only on 0 -> 1 transitions.
             UpdateOnOff(controller_->IsOff(), "ext_mom");
           }

--- a/src/shelly_hap_light_bulb.cpp
+++ b/src/shelly_hap_light_bulb.cpp
@@ -460,7 +460,6 @@ void LightBulb::InputEventHandler(Input::Event ev, bool state) {
     case Input::Event::kChange: {
       switch (static_cast<InMode>(cfg_->in_mode)) {
         case InMode::kMomentary:
-        case InMode::kDetachedWithRelay:
           if (state) {  // Only on 0 -> 1 transitions.
             UpdateOnOff(controller_->IsOff(), "ext_mom");
           }
@@ -488,6 +487,7 @@ void LightBulb::InputEventHandler(Input::Event ev, bool state) {
           break;
         case InMode::kAbsent:
         case InMode::kDetached:
+        case InMode::kDetachedWithRelay:
         case InMode::kMax:
           break;
       }
@@ -500,6 +500,10 @@ void LightBulb::InputEventHandler(Input::Event ev, bool state) {
       }
       break;
     case Input::Event::kSingle:
+       if (in_mode == InMode::kDetachedWithRelay) {
+        UpdateOnOff(controller_->IsOff(), "ext_mom");
+      }
+      break;
     case Input::Event::kDouble:
     case Input::Event::kReset:
     case Input::Event::kMax:

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -209,7 +209,7 @@ void CreateHAPSwitch(int id, const struct mgos_config_sw *sw_cfg,
     acc->AddService(sw2);
     accs->push_back(std::move(acc));
   }
-  if (sw_cfg->in_mode == (int) InMode::kDetached) {
+  if (sw_cfg->in_mode == (int) InMode::kDetached || sw_cfg->in_mode == (int) InMode::kDetachedWithRelay) {
     hap::CreateHAPInput(id, in_cfg, comps, accs, svr);
   }
 }

--- a/src/shelly_switch.cpp
+++ b/src/shelly_switch.cpp
@@ -320,7 +320,6 @@ void ShellySwitch::InputEventHandler(Input::Event ev, bool state) {
     case Input::Event::kChange: {
       switch (static_cast<InMode>(cfg_->in_mode)) {
         case InMode::kMomentary:
-        case InMode::kDetachedWithRelay:
           if (state) {  // Only on 0 -> 1 transitions.
             SetOutputState(!out_->GetState(), "ext_mom");
           }
@@ -348,6 +347,7 @@ void ShellySwitch::InputEventHandler(Input::Event ev, bool state) {
           break;
         case InMode::kAbsent:
         case InMode::kDetached:
+        case InMode::kDetachedWithRelay:
         case InMode::kMax:
           break;
       }
@@ -360,6 +360,10 @@ void ShellySwitch::InputEventHandler(Input::Event ev, bool state) {
       }
       break;
     case Input::Event::kSingle:
+      if (in_mode == InMode::kDetachedWithRelay) {
+        SetOutputState(!out_->GetState(), "ext_mom");
+      }
+      break;
     case Input::Event::kDouble:
     case Input::Event::kReset:
     case Input::Event::kMax:

--- a/src/shelly_switch.cpp
+++ b/src/shelly_switch.cpp
@@ -163,6 +163,8 @@ Status ShellySwitch::SetConfig(const std::string &config_json,
   if (cfg.in_mode != -2 && cfg_->in_mode != cfg.in_mode) {
     if (cfg_->in_mode == (int) InMode::kDetached ||
         cfg.in_mode == (int) InMode::kDetached ||
+        cfg_->in_mode == (int) InMode::kDetachedWithRelay ||
+        cfg.in_mode == (int) InMode::kDetachedWithRelay ||
 #if SHELLY_HAVE_DUAL_INPUT_MODES
         cfg.in_mode == (int) InMode::kEdgeBoth ||
         cfg_->in_mode == (int) InMode::kEdgeBoth ||
@@ -318,6 +320,7 @@ void ShellySwitch::InputEventHandler(Input::Event ev, bool state) {
     case Input::Event::kChange: {
       switch (static_cast<InMode>(cfg_->in_mode)) {
         case InMode::kMomentary:
+        case InMode::kDetachedWithRelay:
           if (state) {  // Only on 0 -> 1 transitions.
             SetOutputState(!out_->GetState(), "ext_mom");
           }


### PR DESCRIPTION
I've tried to do a initial effort for targeting #147, specially on having the single click controlling the relay without relying on HomeKit.

I've created a new input mode, detached with relay control, and i tied the single click to the relay.

I've tried to make it very clean, and maybe there are some limitation, but i've tested in 1PM and 2.5 and its working as expected.