### PR TITLE
gdo option to use second output

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -792,7 +792,8 @@
           <div class="form-control" id="out_mode_container">
             <label>Output Mode:</label>
             <select id="out_mode">
-              <option id="out_mode_0" value="0">Single</option>
+              <option id="out_mode_0" value="0">Single (out 1)</option>
+              <option id="out_mode_2" value="2">Single (out 2)</option>
               <option id="out_mode_1" value="1">Dual</option>
             </select>
           </div>

--- a/mos.yml
+++ b/mos.yml
@@ -88,7 +88,7 @@ config_schema:
   - ["gdo.name", "s", "Garage Door", {title: "Accessory name"}]
   - ["gdo.close_sensor_mode", "i", 0, {title: "Close sensor mode: 0 - normally closed, 1 - normally open"}]
   - ["gdo.open_sensor_mode", "i", 0, {title: "Close sensor mode: 0 - normally closed, 1 - normally open, 2 - disabled"}]
-  - ["gdo.out_mode", "i", 0, {title: "Output mode: 0 - single (open=close=1), 1 - dual (1=open, 2=close)"}]
+  - ["gdo.out_mode", "i", 0, {title: "Output mode: 0 - single (open=close=1), 1 - dual (1=open, 2=close), 2 - single inverted (open=close=1)"}]
   - ["gdo.move_time_ms", "i", 30000, {title: "Movement time, ms"}]
   - ["gdo.begin_move_time_ms", "i", 7000, {title: "Time allowed for movement to begin, ms"}]
   - ["gdo.pulse_time_ms", "i", 300, {title: "Output active time, ms"}]

--- a/src/shelly_hap_garage_door_opener.cpp
+++ b/src/shelly_hap_garage_door_opener.cpp
@@ -146,7 +146,7 @@ Status GarageDoorOpener::SetConfig(const std::string &config_json,
     return mgos::Errorf(STATUS_INVALID_ARGUMENT, "invalid %s",
                         "open_sensor_mode");
   }
-  if (out_mode > 1) {
+  if (out_mode > 2) {
     return mgos::Errorf(STATUS_INVALID_ARGUMENT, "invalid %s", "out_mode");
   }
   // We don't impose a limit on pulse time.
@@ -246,7 +246,8 @@ void GarageDoorOpener::ToggleState(const char *source) {
   State new_state =
       (tgt_state_ == State::kClosed ? State::kOpen : State::kClosed);
   const char *out_src = (new_state == State::kOpen ? "GDO:open" : "GDO:close");
-  if (cfg_->out_mode == 0 || new_state == State::kClosed) {
+  if (cfg_->out_mode == 0 ||
+      (cfg_->out_mode == 1 && new_state == State::kClosed)) {
     out_close_->Pulse(true, cfg_->pulse_time_ms, out_src);
   } else {
     out_open_->Pulse(true, cfg_->pulse_time_ms, out_src);


### PR DESCRIPTION
My intent for this PR is that I reused a damaged UNI (wiring of in1 is removed) for my garage door. That means it can't work in single mode and can only close in double mode. So I added a second single mode which uses out2 instead of out1 like the current single mode does.