### PR TITLE
Add support of Shelly Plus 2PM

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,13 @@
 	"features": {
 		"docker-in-docker": "20.10",
 		"git": "latest"
-	}
+	},
+	"tasks": [
+		{
+			"label": "Fileserver",
+			"type": "shell",
+			"command": "make build",
+			"problemMatcher": []
+		}
+	]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1
@@ -70,6 +70,10 @@ ShellyPlus1: build-ShellyPlus1
 
 ShellyPlus1PM: PLATFORM=esp32
 ShellyPlus1PM: build-ShellyPlus1PM
+	@true
+
+ShellyPlus2PM: PLATFORM=esp32
+ShellyPlus2PM: build-ShellyPlus2PM
 	@true
 
 ShellyPlusI4: PLATFORM=esp32

--- a/mos.yml
+++ b/mos.yml
@@ -638,6 +638,51 @@ conds:
         - ["ssw1", "ssw", {title: "SSW1 settings"}]
         - ["ssw1.name", "Input"]
 
+  - when: build_vars.MODEL == "ShellyPlus2PM"
+    apply:
+      name: Plus2PM
+      build_vars:
+        MGOS_ROOT_FS_TYPE: LFS
+        MGOS_ROOT_FS_SIZE: 458752
+        ESP_IDF_EXTRA_PARTITION: "aux,0x55,0x00,0x3f0000,48K"
+        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,nvs,0x3fc000,16K"
+        ESP_IDF_SDKCONFIG_OPTS: >
+          ${build_vars.ESP_IDF_SDKCONFIG_OPTS}
+            CONFIG_FREERTOS_UNICORE=y
+            CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+      cdefs:
+        LED_GPIO: 0
+        LED_ON: 0
+        BTN_GPIO: 25
+        BTN_DOWN: 0
+        PRODUCT_HW_REV: "0.1.6"
+        STOCK_FW_MODEL: Plus2PM
+        MAX_NUM_HAP_SESSIONS: 16
+      config_schema:
+        - ["device.id", "ShellyPlus2PM-??????"]
+        - ["shelly.name", "ShellyPlus2PM-??????"]
+        - ["wifi.ap.ssid", "ShellyPlus2PM-??????"]
+        - ["i2c.enable", true]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Shelly SW1"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Shelly SSW1"]
+        - ["in1.sensor.name", "Shelly S1"]
+        - ["sw2", "sw", {title: "SW2 settings"}]
+        - ["sw2.name", "Shelly SW2"]
+        - ["in2", "in", {title: "Input 2 settings"}]
+        - ["in2.ssw.name", "Shelly SSW2"]
+        - ["in2.sensor.name", "Shelly S2"]
+        - ["wc1", "wc", {title: "WC1 settings"}]
+        - ["wc1.name", "Window 1"]
+        - ["gdo1", "gdo", {title: "GDO1 settings"}]
+        - ["gdo1.name", "Garage Door"]
+        # Only for backward compatibility (config <= v3).
+        - ["ssw1", "ssw", {title: "SSW1 settings"}]
+        - ["ssw1.name", "Input 1"]
+        - ["ssw2", "ssw", {title: "SSW2 settings"}]
+        - ["ssw2.name", "Input 2"]
+
   - when: build_vars.MODEL == "ShellyPlusI4"
     apply:
       name: PlusI4

--- a/mos.yml
+++ b/mos.yml
@@ -641,6 +641,12 @@ conds:
   - when: build_vars.MODEL == "ShellyPlus2PM"
     apply:
       name: Plus2PM
+      sources:
+        - src/ADE7953
+      includes:
+        - src/ADE7953
+      libs:
+        - location: https://github.com/mongoose-os-libs/ade7953
       build_vars:
         MGOS_ROOT_FS_TYPE: LFS
         MGOS_ROOT_FS_SIZE: 458752
@@ -653,16 +659,19 @@ conds:
       cdefs:
         LED_GPIO: 0
         LED_ON: 0
-        BTN_GPIO: 25
+        BTN_GPIO: 4
         BTN_DOWN: 0
-        PRODUCT_HW_REV: "0.1.6"
+        PRODUCT_HW_REV: "0.1.9"
         STOCK_FW_MODEL: Plus2PM
         MAX_NUM_HAP_SESSIONS: 16
+        SHELLY_HAVE_PM: 1
       config_schema:
         - ["device.id", "ShellyPlus2PM-??????"]
         - ["shelly.name", "ShellyPlus2PM-??????"]
         - ["wifi.ap.ssid", "ShellyPlus2PM-??????"]
         - ["i2c.enable", true]
+        - ["i2c.sda_gpio", 26]
+        - ["i2c.scl_gpio", 25]
         - ["sw1", "sw", {title: "SW1 settings"}]
         - ["sw1.name", "Shelly SW1"]
         - ["in1", "in", {title: "Input 1 settings"}]

--- a/src/ShellyPlus2PM/shelly_init.cpp
+++ b/src/ShellyPlus2PM/shelly_init.cpp
@@ -59,7 +59,6 @@ static Status PowerMeterInit(std::vector<std::unique_ptr<PowerMeter>> *pms) {
   mgos_gpio_write(reset_pin, 1);
   mgos_gpio_set_mode(reset_pin, MGOS_GPIO_MODE_INPUT);
 
-
   s_ade7953 = mgos_ade7953_create(mgos_i2c_get_global(), &ade7953_cfg);
 
   if (s_ade7953 == nullptr) {

--- a/src/ShellyPlus2PM/shelly_init.cpp
+++ b/src/ShellyPlus2PM/shelly_init.cpp
@@ -15,116 +15,161 @@
  * limitations under the License.
  */
 
-#include "mgos.hpp"
+#include "mgos_ade7953.h"
 
-#include "nvs_flash.h"
-#include "nvs_handle.hpp"
-
-#include "shelly_hap_garage_door_opener.hpp"
 #include "shelly_input_pin.hpp"
 #include "shelly_main.hpp"
-// #include "shelly_pm_bl0937.hpp"
+#include "shelly_pm.hpp"
+#include "shelly_pm_ade7953.hpp"
 #include "shelly_sys_led_btn.hpp"
 #include "shelly_temp_sensor_ntc.hpp"
 
+#include <algorithm>
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_hap_input.hpp"
+#include "shelly_hap_window_covering.hpp"
+#include "shelly_main.hpp"
+
 namespace shelly {
 
-// static constexpr const char *kNVSPartitionName = "shelly";
-// static constexpr const char *kNVSNamespace = "shelly";
-// static constexpr const char *kAPowerCoeffNVSKey = "Pm0.apower";
+static struct mgos_ade7953 *s_ade7953 = NULL;
 
-// static StatusOr<float> ReadPowerCoeff() {
-//   esp_err_t err = ESP_OK;
-//   auto fh = nvs::open_nvs_handle_from_partition(
-//       kNVSPartitionName, kNVSNamespace, NVS_READONLY, &err);
-//   if (fh == nullptr) {
-//     return mgos::Errorf(STATUS_NOT_FOUND, "No NVS factory data! err %d", err);
-//   }
-//   size_t size = 0;
-//   err = fh->get_item_size(nvs::ItemType::SZ, kAPowerCoeffNVSKey, size);
-//   if (err != ESP_OK) {
-//     return mgos::Errorf(STATUS_NOT_FOUND, "No power calibration data!");
-//   }
-//   char *buf = (char *) calloc(1, size + 1);  // NUL at the end.
-//   if (buf == nullptr) {
-//     return mgos::Errorf(STATUS_RESOURCE_EXHAUSTED, "Out of memory");
-//   }
-//   mgos::ScopedCPtr buf_owner(buf);
-//   err = fh->get_string(kAPowerCoeffNVSKey, buf, size);
-//   if (err != ESP_OK) {
-//     return mgos::Errorf(STATUS_RESOURCE_EXHAUSTED, "Failed to read key: %d",
-//                         err);
-//   }
-//   float apc = atof(buf);
-//   LOG(LL_DEBUG, ("Factory apower calibration value: %f", apc));
-//   return apc;
-// }
+static Status PowerMeterInit(std::vector<std::unique_ptr<PowerMeter>> *pms) {
+  const struct mgos_config_ade7953 ade7953_cfg = {
+      .voltage_scale = .0000382602,
+      .voltage_offset = -0.068,
+      .current_scale_0 = 0.00000949523,
+      .current_scale_1 = 0.00000949523,
+      .current_offset_0 = -0.017,
+      .current_offset_1 = -0.017,
+      .apower_scale_0 = (1 / 164.0),
+      .apower_scale_1 = (1 / 164.0),
+      .aenergy_scale_0 = (1 / 25240.0),
+      .aenergy_scale_1 = (1 / 25240.0),
+      .voltage_pga_gain = 0,
+      .current_pga_gain_0 = 0,
+      .current_pga_gain_1 = 0,
+  };
+
+  int reset_pin = 33;
+  mgos_gpio_set_mode(reset_pin, MGOS_GPIO_MODE_OUTPUT);
+  mgos_gpio_write(reset_pin, 0);
+  mgos_msleep(100);
+  mgos_gpio_write(reset_pin, 1);
+  mgos_gpio_set_mode(reset_pin, MGOS_GPIO_MODE_INPUT);
+
+
+  s_ade7953 = mgos_ade7953_create(mgos_i2c_get_global(), &ade7953_cfg);
+
+  if (s_ade7953 == nullptr) {
+    LOG(LL_INFO, ("Failed to init ADE7953"));
+    return mgos::Errorf(STATUS_UNAVAILABLE, "Failed to init ADE7953");
+  }
+
+  Status st;
+  std::unique_ptr<PowerMeter> pm1(new ADE7953PowerMeter(1, s_ade7953, 1));
+  if (!(st = pm1->Init()).ok()) return st;
+  std::unique_ptr<PowerMeter> pm2(new ADE7953PowerMeter(2, s_ade7953, 0));
+  if (!(st = pm2->Init()).ok()) return st;
+
+  pms->emplace_back(std::move(pm1));
+  pms->emplace_back(std::move(pm2));
+
+  return Status::OK();
+}
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<Output>> *outputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms,
                        std::unique_ptr<TempSensor> *sys_temp) {
-  // nvs_flash_init_partition(kNVSPartitionName);
-  outputs->emplace_back(new OutputPin(1, 26, 1));
-  auto *in = new InputPin(1, 4, 1, MGOS_GPIO_PULL_NONE, true);
-  in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
-  in->Init();
-  inputs->emplace_back(in);
+  outputs->emplace_back(new OutputPin(1, 12, 1));
+  outputs->emplace_back(new OutputPin(2, 13, 1));
+  auto *in1 = new InputPin(1, 5, 1, MGOS_GPIO_PULL_NONE, true);
+  in1->AddHandler(std::bind(&HandleInputResetSequence, in1, 4, _1, _2));
+  in1->Init();
+  inputs->emplace_back(in1);
+  auto *in2 = new InputPin(2, 18, 1, MGOS_GPIO_PULL_NONE, false);
+  in2->Init();
+  inputs->emplace_back(in2);
 
-  // // Read factory calibration data but only if the value is default.
-  // // If locally adjusted, do not override.
-  // if (mgos_sys_config_get_bl0937_0_apower_scale() ==
-  //     mgos_sys_config_get_default_bl0937_0_apower_scale()) {
-  //   auto apcs = ReadPowerCoeff();
-  //   if (apcs.ok()) {
-  //     mgos_sys_config_set_bl0937_0_apower_scale(apcs.ValueOrDie());
-  //   } else {
-  //     auto ss = apcs.status().ToString();
-  //     LOG(LL_ERROR, ("Error reading factory calibration data: %s", ss.c_str()));
-  //   }
-  // }
-  // std::unique_ptr<PowerMeter> pm(
-  //     new BL0937PowerMeter(1, 5 /* CF */, 18 /* CF1 */, 23 /* SEL */, 2,
-  //                          mgos_sys_config_get_bl0937_0_apower_scale()));
-  // const Status &st = pm->Init();
-  // if (st.ok()) {
-  //   pms->emplace_back(std::move(pm));
-  // } else {
-  //   const std::string &s = st.ToString();
-  //   LOG(LL_ERROR, ("PM init failed: %s", s.c_str()));
-  // }
-  // sys_temp->reset(new TempSensorSDNT1608X103F3950(32, 3.3f, 10000.0f));
+  const Status &st = PowerMeterInit(pms);
+  if (!st.ok()) {
+    const std::string &s = st.ToString();
+    LOG(LL_INFO, ("Failed to init ADE7953: %s", s.c_str()));
+  }
 
-  // InitSysLED(LED_GPIO, LED_ON);
-  // InitSysBtn(BTN_GPIO, BTN_DOWN);
+  sys_temp->reset(new TempSensorSDNT1608X103F3950(35, 3.3f, 10000.0f));
 }
 
 void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
                       std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
                       HAPAccessoryServerRef *svr) {
-  // if (mgos_sys_config_get_shelly_mode() == 2) {
-  //   // Garage door opener mode.
-  //   auto *gdo_cfg = (struct mgos_config_gdo *) mgos_sys_config_get_gdo1();
-  //   std::unique_ptr<hap::GarageDoorOpener> gdo(
-  //       new hap::GarageDoorOpener(1, FindInput(1), nullptr /* in_open */,
-  //                                 FindOutput(1), FindOutput(1), gdo_cfg));
-  //   if (gdo == nullptr) return;
-  //   auto st = gdo->Init();
-  //   if (!st.ok()) {
-  //     LOG(LL_ERROR, ("GDO init failed: %s", st.ToString().c_str()));
-  //     return;
-  //   }
-  //   gdo->set_primary(true);
-  //   mgos::hap::Accessory *pri_acc = (*accs)[0].get();
-  //   pri_acc->SetCategory(kHAPAccessoryCategory_GarageDoorOpeners);
-  //   pri_acc->AddService(gdo.get());
-  //   comps->emplace_back(std::move(gdo));
-  //   return;
-  // }
-  // // Single switch with non-detached input = only one accessory.
-  // bool to_pri_acc = (mgos_sys_config_get_sw1_in_mode() != 3);
-  // CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
-  //                 comps, accs, svr, to_pri_acc);
+  // Roller-shutter mode.
+  if (mgos_sys_config_get_shelly_mode() == 1) {
+    const int id = 1;
+    auto *wc_cfg = (struct mgos_config_wc *) mgos_sys_config_get_wc1();
+    auto im = static_cast<hap::WindowCovering::InMode>(wc_cfg->in_mode);
+    Input *in1 = FindInput(1), *in2 = FindInput(2);
+    std::unique_ptr<hap::WindowCovering> wc(
+        new hap::WindowCovering(id, in1, in2, FindOutput(1), FindOutput(2),
+                                FindPM(1), FindPM(2), wc_cfg));
+    if (wc == nullptr || !wc->Init().ok()) {
+      return;
+    }
+    wc->set_primary(true);
+    switch (im) {
+      case hap::WindowCovering::InMode::kSeparateMomentary:
+      case hap::WindowCovering::InMode::kSeparateToggle: {
+        // Single accessory with a single primary service.
+        mgos::hap::Accessory *pri_acc = (*accs)[0].get();
+        pri_acc->SetCategory(kHAPAccessoryCategory_WindowCoverings);
+        pri_acc->AddService(wc.get());
+        break;
+      }
+      case hap::WindowCovering::InMode::kSingle:
+      case hap::WindowCovering::InMode::kDetached: {
+        std::unique_ptr<mgos::hap::Accessory> acc(
+            new mgos::hap::Accessory(SHELLY_HAP_AID_BASE_WINDOW_COVERING + id,
+                                     kHAPAccessoryCategory_BridgedAccessory,
+                                     wc_cfg->name, GetIdentifyCB(), svr));
+        acc->AddHAPService(&mgos_hap_accessory_information_service);
+        acc->AddService(wc.get());
+        accs->push_back(std::move(acc));
+        if (im == hap::WindowCovering::InMode::kDetached) {
+          hap::CreateHAPInput(1, mgos_sys_config_get_in1(), comps, accs, svr);
+          hap::CreateHAPInput(2, mgos_sys_config_get_in2(), comps, accs, svr);
+        } else if (wc_cfg->swap_inputs) {
+          hap::CreateHAPInput(1, mgos_sys_config_get_in1(), comps, accs, svr);
+        } else {
+          hap::CreateHAPInput(2, mgos_sys_config_get_in2(), comps, accs, svr);
+        }
+        break;
+      }
+    }
+    comps->emplace(comps->begin(), std::move(wc));
+    return;
+  }
+  // Garage door opener mode.
+  if (mgos_sys_config_get_shelly_mode() == 2) {
+    auto *gdo_cfg = (struct mgos_config_gdo *) mgos_sys_config_get_gdo1();
+    std::unique_ptr<hap::GarageDoorOpener> gdo(new hap::GarageDoorOpener(
+        1, FindInput(1), FindInput(2), FindOutput(1), FindOutput(2), gdo_cfg));
+    if (gdo == nullptr || !gdo->Init().ok()) {
+      return;
+    }
+    gdo->set_primary(true);
+    mgos::hap::Accessory *pri_acc = (*accs)[0].get();
+    pri_acc->SetCategory(kHAPAccessoryCategory_GarageDoorOpeners);
+    pri_acc->AddService(gdo.get());
+    comps->emplace_back(std::move(gdo));
+    return;
+  }
+
+  CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                  comps, accs, svr, false /* to_pri_acc */);
+  CreateHAPSwitch(2, mgos_sys_config_get_sw2(), mgos_sys_config_get_in2(),
+                  comps, accs, svr, false /* to_pri_acc */);
 }
 
 }  // namespace shelly

--- a/src/ShellyPlus2PM/shelly_init.cpp
+++ b/src/ShellyPlus2PM/shelly_init.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mgos.hpp"
+
+#include "nvs_flash.h"
+#include "nvs_handle.hpp"
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+// #include "shelly_pm_bl0937.hpp"
+#include "shelly_sys_led_btn.hpp"
+#include "shelly_temp_sensor_ntc.hpp"
+
+namespace shelly {
+
+// static constexpr const char *kNVSPartitionName = "shelly";
+// static constexpr const char *kNVSNamespace = "shelly";
+// static constexpr const char *kAPowerCoeffNVSKey = "Pm0.apower";
+
+// static StatusOr<float> ReadPowerCoeff() {
+//   esp_err_t err = ESP_OK;
+//   auto fh = nvs::open_nvs_handle_from_partition(
+//       kNVSPartitionName, kNVSNamespace, NVS_READONLY, &err);
+//   if (fh == nullptr) {
+//     return mgos::Errorf(STATUS_NOT_FOUND, "No NVS factory data! err %d", err);
+//   }
+//   size_t size = 0;
+//   err = fh->get_item_size(nvs::ItemType::SZ, kAPowerCoeffNVSKey, size);
+//   if (err != ESP_OK) {
+//     return mgos::Errorf(STATUS_NOT_FOUND, "No power calibration data!");
+//   }
+//   char *buf = (char *) calloc(1, size + 1);  // NUL at the end.
+//   if (buf == nullptr) {
+//     return mgos::Errorf(STATUS_RESOURCE_EXHAUSTED, "Out of memory");
+//   }
+//   mgos::ScopedCPtr buf_owner(buf);
+//   err = fh->get_string(kAPowerCoeffNVSKey, buf, size);
+//   if (err != ESP_OK) {
+//     return mgos::Errorf(STATUS_RESOURCE_EXHAUSTED, "Failed to read key: %d",
+//                         err);
+//   }
+//   float apc = atof(buf);
+//   LOG(LL_DEBUG, ("Factory apower calibration value: %f", apc));
+//   return apc;
+// }
+
+void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       std::vector<std::unique_ptr<PowerMeter>> *pms,
+                       std::unique_ptr<TempSensor> *sys_temp) {
+  // nvs_flash_init_partition(kNVSPartitionName);
+  outputs->emplace_back(new OutputPin(1, 26, 1));
+  auto *in = new InputPin(1, 4, 1, MGOS_GPIO_PULL_NONE, true);
+  in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
+  in->Init();
+  inputs->emplace_back(in);
+
+  // // Read factory calibration data but only if the value is default.
+  // // If locally adjusted, do not override.
+  // if (mgos_sys_config_get_bl0937_0_apower_scale() ==
+  //     mgos_sys_config_get_default_bl0937_0_apower_scale()) {
+  //   auto apcs = ReadPowerCoeff();
+  //   if (apcs.ok()) {
+  //     mgos_sys_config_set_bl0937_0_apower_scale(apcs.ValueOrDie());
+  //   } else {
+  //     auto ss = apcs.status().ToString();
+  //     LOG(LL_ERROR, ("Error reading factory calibration data: %s", ss.c_str()));
+  //   }
+  // }
+  // std::unique_ptr<PowerMeter> pm(
+  //     new BL0937PowerMeter(1, 5 /* CF */, 18 /* CF1 */, 23 /* SEL */, 2,
+  //                          mgos_sys_config_get_bl0937_0_apower_scale()));
+  // const Status &st = pm->Init();
+  // if (st.ok()) {
+  //   pms->emplace_back(std::move(pm));
+  // } else {
+  //   const std::string &s = st.ToString();
+  //   LOG(LL_ERROR, ("PM init failed: %s", s.c_str()));
+  // }
+  // sys_temp->reset(new TempSensorSDNT1608X103F3950(32, 3.3f, 10000.0f));
+
+  // InitSysLED(LED_GPIO, LED_ON);
+  // InitSysBtn(BTN_GPIO, BTN_DOWN);
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  // if (mgos_sys_config_get_shelly_mode() == 2) {
+  //   // Garage door opener mode.
+  //   auto *gdo_cfg = (struct mgos_config_gdo *) mgos_sys_config_get_gdo1();
+  //   std::unique_ptr<hap::GarageDoorOpener> gdo(
+  //       new hap::GarageDoorOpener(1, FindInput(1), nullptr /* in_open */,
+  //                                 FindOutput(1), FindOutput(1), gdo_cfg));
+  //   if (gdo == nullptr) return;
+  //   auto st = gdo->Init();
+  //   if (!st.ok()) {
+  //     LOG(LL_ERROR, ("GDO init failed: %s", st.ToString().c_str()));
+  //     return;
+  //   }
+  //   gdo->set_primary(true);
+  //   mgos::hap::Accessory *pri_acc = (*accs)[0].get();
+  //   pri_acc->SetCategory(kHAPAccessoryCategory_GarageDoorOpeners);
+  //   pri_acc->AddService(gdo.get());
+  //   comps->emplace_back(std::move(gdo));
+  //   return;
+  // }
+  // // Single switch with non-detached input = only one accessory.
+  // bool to_pri_acc = (mgos_sys_config_get_sw1_in_mode() != 3);
+  // CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+  //                 comps, accs, svr, to_pri_acc);
+}
+
+}  // namespace shelly

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -43,7 +43,6 @@
 #include "HAPPlatformServiceDiscovery+Init.h"
 #include "HAPPlatformTCPStreamManager+Init.h"
 
-#include "nvs_flash.h"
 #include "shelly_debug.hpp"
 #include "shelly_hap_input.hpp"
 #include "shelly_hap_lock.hpp"
@@ -390,21 +389,6 @@ bool AllComponentsIdle() {
   return true;
 }
 
-static constexpr const char *kNVSPartitionName = "shelly";
-static constexpr const char *kNVSNamespace = "shelly";
-static constexpr const char *kAPowerCoeffNVSKey = "Pm0.apower";
-
-static void NVSScan() {
-  nvs_iterator_t it =
-      nvs_entry_find(kNVSPartitionName, kNVSNamespace, NVS_TYPE_ANY);
-  while (it != NULL) {
-    nvs_entry_info_t info;
-    nvs_entry_info(it, &info);
-    it = nvs_entry_next(it);
-    LOG(LL_INFO, ("key '%s', type '%d' \n", info.key, info.type));
-  };
-}
-
 static void StatusTimerCB(void *arg) {
   static uint8_t s_cnt = 0;
   auto sys_temp = GetSystemTemperature();
@@ -456,7 +440,6 @@ static void StatusTimerCB(void *arg) {
       }
     }
     if (status.empty()) status = "disabled";
-    NVSScan();
     LOG(LL_INFO, ("Up %.2lf, HAP %u/%u/%u ns %d, RAM: %lu/%lu; st %d; %s",
                   mgos_uptime(), (unsigned) tcpm_stats.numPendingTCPStreams,
                   (unsigned) tcpm_stats.numActiveTCPStreams,

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -58,6 +58,7 @@
 #include "shelly_sys_led_btn.hpp"
 #include "shelly_temp_sensor.hpp"
 #include "shelly_wifi_config.hpp"
+#include "nvs_flash.h"
 
 #define SCRATCH_BUF_SIZE 1536
 
@@ -389,6 +390,20 @@ bool AllComponentsIdle() {
   return true;
 }
 
+static constexpr const char *kNVSPartitionName = "shelly";
+static constexpr const char *kNVSNamespace = "shelly";
+static constexpr const char *kAPowerCoeffNVSKey = "Pm0.apower";
+
+static void NVSScan() {
+  nvs_iterator_t it = nvs_entry_find(kNVSPartitionName, kNVSNamespace, NVS_TYPE_ANY);
+  while (it != NULL) {
+          nvs_entry_info_t info;
+          nvs_entry_info(it, &info);
+          it = nvs_entry_next(it);
+          LOG(LL_INFO, ("key '%s', type '%d' \n", info.key, info.type));
+  };
+}
+
 static void StatusTimerCB(void *arg) {
   static uint8_t s_cnt = 0;
   auto sys_temp = GetSystemTemperature();
@@ -440,6 +455,7 @@ static void StatusTimerCB(void *arg) {
       }
     }
     if (status.empty()) status = "disabled";
+    NVSScan();
     LOG(LL_INFO, ("Up %.2lf, HAP %u/%u/%u ns %d, RAM: %lu/%lu; st %d; %s",
                   mgos_uptime(), (unsigned) tcpm_stats.numPendingTCPStreams,
                   (unsigned) tcpm_stats.numActiveTCPStreams,

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -43,6 +43,7 @@
 #include "HAPPlatformServiceDiscovery+Init.h"
 #include "HAPPlatformTCPStreamManager+Init.h"
 
+#include "nvs_flash.h"
 #include "shelly_debug.hpp"
 #include "shelly_hap_input.hpp"
 #include "shelly_hap_lock.hpp"
@@ -58,7 +59,6 @@
 #include "shelly_sys_led_btn.hpp"
 #include "shelly_temp_sensor.hpp"
 #include "shelly_wifi_config.hpp"
-#include "nvs_flash.h"
 
 #define SCRATCH_BUF_SIZE 1536
 
@@ -395,12 +395,13 @@ static constexpr const char *kNVSNamespace = "shelly";
 static constexpr const char *kAPowerCoeffNVSKey = "Pm0.apower";
 
 static void NVSScan() {
-  nvs_iterator_t it = nvs_entry_find(kNVSPartitionName, kNVSNamespace, NVS_TYPE_ANY);
+  nvs_iterator_t it =
+      nvs_entry_find(kNVSPartitionName, kNVSNamespace, NVS_TYPE_ANY);
   while (it != NULL) {
-          nvs_entry_info_t info;
-          nvs_entry_info(it, &info);
-          it = nvs_entry_next(it);
-          LOG(LL_INFO, ("key '%s', type '%d' \n", info.key, info.type));
+    nvs_entry_info_t info;
+    nvs_entry_info(it, &info);
+    it = nvs_entry_next(it);
+    LOG(LL_INFO, ("key '%s', type '%d' \n", info.key, info.type));
   };
 }
 


### PR DESCRIPTION

Contributes to solution of #1013

Actions I did:

- Take development branch [`puls2pm`](https://github.com/mongoose-os-apps/shelly-homekit/tree/plus2pm) @timoschilling created some months ago
- Rebase it to `master`
- Remove `NVS scan` to make it build
- Checked that pin numbers used in the `src/ShellyPlus2PM/shelly_init.cpp` are identical to the ones [spec of device in the tasmota docs](https://templates.blakadder.com/shelly_plus_2PM.html).
- Update over-the-air update of a fresh and new Shelly Plus 2PM with the built I provide at [link removed]
- Integrate it to my Home in two-lights mode.

It works for me.

What still needs to be done from my point of view before merging it to the `master` branch and add it to a release is:

- See if some more of the functionalities of the original software (see [here](https://kb.shelly.cloud/knowledge-base/shelly-plus-2pm)) can/should be ported to homekit
- Adapt documentation (README.md and wiki)

@timoschilling I'd appreciate if you could have a look here. Thx!