### PR TITLE
New switch input mode: Activation Once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ fs/conf*.json
 flash-shelly.auth.yaml
 *.cfg.yaml
 .venv
+.idea
+/*.sh

--- a/Makefile
+++ b/Makefile
@@ -143,3 +143,8 @@ check-format: format
 
 upload:
 	rsync -azv releases/* rojer.me:www/files/shelly/
+
+clean:
+	rm -rf build_* releases binlibs deps fs/index.html.gz
+
+all: build

--- a/docs/input-modes.md
+++ b/docs/input-modes.md
@@ -1,0 +1,88 @@
+## Switches and light bulbs input modes
+
+### Input modes comparison
+
+| Current<br/>state of<br/>output | Input change<br/>scenario | Momentary | Toggle | Edge  | Detached |    Activation     | Activation Once |
+|:-------------------------------:|:-------------------------:|:---------:|:------:|:-----:|:--------:|:-----------------:|:---------------:|
+|              `OFF`              |           `→ON`           |   `ON`    |  `ON`  | `ON`  |   `-`    |       `ON`        |      `ON`       |
+|              `ON`               |          `→OFF`           |    `-`    | `OFF`  | `OFF` |   `-`    |   `Timer reset`   |       `-`       |
+|              `OFF`              |          `→OFF`           |    `-`    |  `-`   | `ON`  |   `-`    |        `-`        |       `-`       |
+|              `ON`               |           `→ON`           |   `OFF`   |  `-`   | `OFF` |   `-`    | `Timer reset`[^1] |       `-`       |
+
+[^1]: Except for the LED lights (RGBW2, Bulb, Duo, Vintage)
+
+#### Input change scenarios:
+
+- `→ON`: Input changes from `OFF` to `ON`. Examples:
+    - External switch is turned on
+    - Doorbell button is pressed (but not released yet)
+    - 2-way switch is flipped to the other position
+- `→OFF`: Input changes from `ON` to `OFF`. Examples:
+    - External switch is turned off
+    - Doorbell button is released (if was pressed before)
+    - 2-way switch is flipped to the other position
+
+#### Output outcomes:
+
+- `ON`: Output turns `ON`, Auto-off timer started[^2].
+- `OFF`: Output turns `OFF`, Auto-off timer is stopped[^2].
+- `-`: Output stays the same (`ON` if was `ON`, `OFF` if was `OFF`), Auto-off timer also stays the same (running if was
+  started, stopped if was stopped)[^2].
+- `Timer reset`: Output stays `ON`, Auto-off timer is reset (restarted if was running, started if was stopped)[^2].
+
+[^2]: Considering the Auto-off timer is enabled in the device configuration.
+
+### Input modes use cases and examples
+
+#### Momentary
+
+Can be used in conjunction with a stateless switch (doorbell button). **Single press of the button will flip the output
+**
+state (turn on if was off, turn off if was on). The output will stay in that state until the next button press.
+
+#### Toggle
+
+In conjunction with a stateful switch 1-way. Usage with 2-way switch is possible, but Edge mode is a better fit for that
+case. The output will **copy the state of the switch** (at the time of the press). Meaning, if the switch flips on, the
+output will turn on, if the switch flips off, the output will turn off.
+
+On the other hand, if the output was already on, and the switch flips from "off" to "on", the output will not change,
+and vice versa. So in the scenario where the lights were turned on from the app, while the switch was in the "off"
+position, flipping the switch to "on" will not change the output state (the lights will stay on). To turn the lights
+off, the switch needs to be flipped to "on" and then back to "off" (double flip).
+
+#### Edge
+
+In conjunction with a stateful 1-way or 2-way switch. The output will turn change state to the opposite (turn on if was
+off, turn off if was on) when the switch is flipped from any state to any other. Meaning, if the output was off, and the
+switch was flipped from "on" to "off", the output will turn on and vice versa.
+
+On the other hand, this may (and often will) lead to the situation where the state of the physical switch and the output
+are different (lights are on, while the switch is in the "off" position). For example, if the lights were turned on
+from the app, while the switch was in the "off" position, flipping the switch to "on" will turn the lights off.
+
+#### Detached
+
+The switch has no effect on the output. The output can be controlled only from the app.
+
+#### Activation
+
+In conjunction with a stateless switch (doorbell button) or a motion sensor and the Auto-off timer. The output will turn
+on when the switch is pressed (or motion is detected), and will turn off only after the Auto-off timer expires. If
+during the timer countdown the switch is pressed again (or motion is detected again), the timer will be reset and the
+output will stay on.
+
+Note the different behavior for the LED lights (RGBW2, Bulb, Duo, Vintage) and the rest of the devices:
+In LED lights the timer is not reset when the signal from the button or motion sensor stops.
+In contrast, on the other devices, the timer will reset if the signal disappears (for example when motion stops).
+
+#### Activation Once
+
+In conjunction with an external timer (for example, christmas lights or pool timer) to turn the device on and internal
+Auto-off timer to turn it off. The output will turn on when ether the external timer turns on or it is turned on from
+the app, and will turn off only after the Auto-off timer expires, no matter how the input changes. If during the
+auto-off timer countdown the external timer turns on or off, this will have no effect on the output.
+
+This is useful for example for a pool pump, where you have an external timer to turn it on at 15:00 every day (a setting
+of the external timer) and run for 2 hours (a setting of the internal auto-off timer), but you want to be able to
+override the external timer (start early) from the app on demand.

--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -494,6 +494,7 @@
               <option id="in_mode_4" value="4">Activation</option>
               <option id="in_mode_5" value="5">Edge (both inputs)</option>
               <option id="in_mode_6" value="6">Activation (both inputs)</option>
+              <option id="in_mode_7" value="7">Activation Once</option>
             </select>
           </div>
           <div class="form-control" id="in_inverted_container" style="display: none">
@@ -900,6 +901,7 @@
                 <option id="in_mode_2" value="2">Edge</option>
                 <option id="in_mode_3" value="3">Detached</option>
                 <option id="in_mode_4" value="4">Activation</option>
+                <option id="in_mode_7" value="7">Activation Once</option>
               </select>
             </div>
             <div class="form-control" id="in_inverted_container" style="display: none">

--- a/mos.yml
+++ b/mos.yml
@@ -48,7 +48,7 @@ config_schema:
   - ["sw.name", "s", "", {title: "Name of the switch"}]
   - ["sw.enable", "b", true, {title: "Enable this switch in the accessory"}]
   - ["sw.out_inverted", "b", false, {title: "Invert output, set to true for normally open output"}]
-  - ["sw.in_mode", "i", 1, {title: "-1 - Absent, 0 - Momentary, 1 - Toggle, 2 - Edge, 3 - Detached"}]
+  - ["sw.in_mode", "i", 1, {title: "-1 - Absent, 0 - Momentary, 1 - Toggle, 2 - Edge, 3 - Detached, 4 - Activation, 7 - Activation Once"}]
   - ["sw.in_inverted", "b", false, {title: "Invert input, set to true for normally closed input"}]
   - ["sw.state", "b", false, {title: "State of the switch"}]
   - ["sw.svc_type", "i", 0, {title: "HAP service type, -1 = disable, 0 = switch, 1 = outlet, 2 = lock, 3 = valve"}]

--- a/src/shelly_common.hpp
+++ b/src/shelly_common.hpp
@@ -111,6 +111,7 @@ enum class InMode {
   kEdgeBoth = 5,
   kActivationBoth = 6,
 #endif
+  kActivationOnce = 7,
   kMax,
 };
 

--- a/src/shelly_hap_light_bulb.cpp
+++ b/src/shelly_hap_light_bulb.cpp
@@ -499,6 +499,15 @@ void LightBulb::InputEventHandler(Input::Event ev, bool state) {
             ResetAutoOff();
           }
           break;
+        case InMode::kActivationOnce:
+          // On 0 -> 1 we turn on output and arm auto off timer.
+          // on 1 -> 1 we do nothing (handled by UpdateOnOff()),
+          // on 0 -> 0 we do nothing (handled by UpdateOnOff()),
+          // on 1 -> 0 we do nothing (handled by "if" below),
+          if (state && !controller_->IsOn()) {
+            UpdateOnOff(true, "ext_act_once");
+          }
+          break;
         case InMode::kAbsent:
         case InMode::kDetached:
         case InMode::kMax:

--- a/src/shelly_switch.cpp
+++ b/src/shelly_switch.cpp
@@ -357,6 +357,15 @@ void ShellySwitch::InputEventHandler(Input::Event ev, bool state) {
             auto_off_timer_.Reset(cfg_->auto_off_delay * 1000, 0);
           }
           break;
+        case InMode::kActivationOnce:
+          // On 0 -> 1 we turn on output and arm auto off timer.
+          // on 1 -> 1 we do nothing
+          // on 0 -> 0 we do nothing
+          // on 1 -> 0 we do nothing
+          if (state && !GetOutputState()) {
+            SetOutputState(true, "ext_act_once");
+          }
+          break;
         case InMode::kAbsent:
         case InMode::kDetached:
         case InMode::kMax:


### PR DESCRIPTION
This PR introduces a new input mode called "Activation Once". This mode is designed to work with external timers or sensors, allowing the device to be turned on once and then automatically turned off after a pre-configured duration, regardless of further input changes.

The changes include:

- Modifying the `fs_src/index.html` file to add the "Activation Once" option to the input mode selection in the device's web interface.
- Updating the `mos.yml` configuration schema to include the new input mode option.
- Extending the `InMode` enum in `src/shelly_common.hpp` to include the `kActivationOnce` value.
- Implementing the behavior of the "Activation Once" mode in `src/shelly_hap_light_bulb.cpp` and `src/shelly_switch.cpp` to handle input events according to the new mode's logic.
- Creating a new documentation file `docs/input-modes.md` that explains the different input modes available for Shelly devices, including the new "Activation Once" mode.

The "Activation Once" mode is particularly useful for scenarios where a device needs to be turned on at a specific time (e.g., via an external timer) and then turned off automatically after a set period, without being affected by subsequent input changes. This can be beneficial for applications such as pool pumps, garden lights, or other timed events where manual override from the app is also desired.