### PR TITLE
Fix complaint when zeroconf returns props with a value of None

### DIFF
--- a/tools/flash-shelly.py
+++ b/tools/flash-shelly.py
@@ -223,7 +223,7 @@ class ServiceListener:  # handle device(s) found by DNS scanner.
       fw_type = None
       wifi_ip = socket.inet_ntoa(info.addresses[0])
       properties = info.properties
-      properties = {y.decode('UTF-8'): properties.get(y).decode('UTF-8') for y in properties.keys()}
+      properties = {y.decode('UTF-8'): properties.get(y).decode('UTF-8') for y in properties.keys() if properties.get(y) is not None}
       logger.debug(f"[Device Scan] found device: {host}, IP address: {wifi_ip}")
       logger.trace(f"[Device Scan] info: {info}")
       logger.trace(f"[Device Scan] properties: {properties}")


### PR DESCRIPTION
zeroconf can return a properties dict like:

{b'': None}

for certain devices.  The HP OfficeJet Pro 9010 is one such device.  This causes update script to display the exception to the user, since the comprehension is expecting all of the values to be strings.
