### PR TITLE
Support for Mini 1 Gen 3 / Mini 1PM Gen 3 / Plus 1 Mini

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
           - ShellyPlusI4
           - ShellyPlusPlugS
           - ShellyPlusRGBWPM
+          - ShellyPlus1Mini
           - ShellyMini1Gen3
           - ShellyMini1PMGen3
           - ShellyRGBW2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
           - ShellyPlusI4
           - ShellyPlusPlugS
           - ShellyPlusRGBWPM
+          - ShellyMini1Gen3
           - ShellyRGBW2
           - ShellyUNI
           - ShellyVintage
@@ -35,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build docker image # remove if newer mos docker image is available
-        if: ${{ contains( matrix.model , 'Plus') }}
+        if: ${{ contains( matrix.model , 'Plus') || contains( matrix.model , 'G3') }}
         run: docker build -t mgos/esp32-build:4.4.1-r7 -f .github/workflows/Dockerfile-esp32-build .
       - name: Install mos build tool
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
           - ShellyPlusPlugS
           - ShellyPlusRGBWPM
           - ShellyMini1Gen3
+          - ShellyMini1PMGen3
           - ShellyRGBW2
           - ShellyUNI
           - ShellyVintage

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build docker image # remove if newer mos docker image is available
-        if: ${{ contains( matrix.model , 'Plus') || contains( matrix.model , 'G3') }}
+        if: ${{ contains( matrix.model , 'Plus') || contains( matrix.model , 'Gen3') }}
         run: docker build -t mgos/esp32-build:4.4.1-r7 -f .github/workflows/Dockerfile-esp32-build .
       - name: Install mos build tool
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI ShellyPlusRGBWPM
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI ShellyPlusRGBWPM
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1
@@ -86,6 +86,10 @@ ShellyPlusRGBWPM: build-ShellyPlusRGBWPM
 
 ShellyPlusI4: PLATFORM=esp32
 ShellyPlusI4: build-ShellyPlusI4
+	@true
+
+ShellyPlus1Mini: PLATFORM=esp32
+ShellyPlus1Mini: build-ShellyPlus1Mini
 	@true
 
 ShellyMini1Gen3: PLATFORM=esp32c3

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
 .PHONY: build check-format format release upload \
-        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM
+        Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyUDuo ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM ShellyMini1Gen3 ShellyMini1PMGen3
 .SUFFIXES:
 
 MOS ?= mos
@@ -27,7 +27,7 @@ ifneq "$(VERBOSE)$(V)" "00"
   MOS_BUILD_FLAGS_FINAL += --verbose
 endif
 
-build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM
+build: Shelly1 Shelly1L Shelly1PM Shelly25 Shelly2 ShellyColorBulb ShellyDuo ShellyI3 ShellyPlug ShellyPlugS ShellyPlusPlugS ShellyPlus1 ShellyPlus1PM ShellyPlus2PM ShellyPlusI4 ShellyRGBW2 ShellyVintage ShellyU ShellyU25 ShellyURGBW2 ShellyUNI ShellyPlus1Mini ShellyPlusRGBWPM ShellyMini1Gen3 ShellyMini1PMGen3
 
 release:
 	$(MAKE) build CLEAN=1 RELEASE=1

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ ShellyMini1Gen3: PLATFORM=esp32c3
 ShellyMini1Gen3: build-ShellyMini1Gen3
 	@true
 
+ShellyMini1PMGen3: PLATFORM=esp32c3
+ShellyMini1PMGen3: build-ShellyMini1PMGen3
+	@true
+
 ShellyRGBW2: build-ShellyRGBW2
 	@true
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ ShellyPlusI4: PLATFORM=esp32
 ShellyPlusI4: build-ShellyPlusI4
 	@true
 
+ShellyMini1Gen3: PLATFORM=esp32c3
+ShellyMini1Gen3: build-ShellyMini1Gen3
+	@true
+
 ShellyRGBW2: build-ShellyRGBW2
 	@true
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Reverting to stock firmware is also possible [see here](https://github.com/mongo
 
 ### Plus devices
 
-|                                            |[+1]|[+1PM]|[+2PM]|+i4 [AC]/[DC]|[+Plug S]
-|-                                           |-   |-     |-     |-            |-     
-|Switch & Co.<sup>1</sup>                    |✓   |✓     |✓     |✗            |✓     
-|Stateless Input<sup>2</sup>                 |✓   |✓     |✓     |✓            |✗    
-|Sensors<sup>3</sup>                         |✓   |✓     |✓     |✓            |✗     
-|Garage door opener                          |✓   |✓     |✓     |✗            |✗     
-|Roller shutter mode                         |✗   |✗     |✓     |✗            |✗     
-|Power measurement                           |✗   |✓     |✓     |✗            |✓     
-|Temperature/Humidity measurement<sup>4</sup>|✓   |✓     |✓     |✓            |✗     
+|                                            |[+1]|[+1Mini]|[+1PM]|[+2PM]|+i4 [AC]/[DC]|[+Plug S]
+|-                                           |-   |-       |-     |-     |-            |-     
+|Switch & Co.<sup>1</sup>                    |✓   |✓       |✓     |✓     |✗            |✓     
+|Stateless Input<sup>2</sup>                 |✓   |✓       |✓     |✓     |✓            |✗    
+|Sensors<sup>3</sup>                         |✓   |✗       |✓     |✓     |✓            |✗     
+|Garage door opener                          |✓   |✓       |✓     |✓     |✗            |✗     
+|Roller shutter mode                         |✗   |✗       |✗     |✓     |✗            |✗     
+|Power measurement                           |✗   |✗       |✓     |✓     |✗            |✓     
+|Temperature/Humidity measurement<sup>4</sup>|✓   |✗       |✓     |✓     |✓            |✗     
 
 ### Light Controllers
 
@@ -163,12 +163,19 @@ See [here](https://github.com/mongoose-os-apps/shelly-homekit/wiki/Development) 
 
 See [here](AUTHORS.md).
 
+## Support
+
+If you like the project, consider a Donation to markib via [Paypal](https://www.paypal.com/donate/?hosted_button_id=RVFA9G5VMXRX8)
+
 ## License
 
 This firmware is free software and is distributed under [Apache 2.0 license](LICENSE).
 
 [1]: https://www.shelly.cloud/en/products/shop/1xs1
 [+1]: https://www.shelly.cloud/en/products/shop/shelly-plus-1
+[+1Mini]: https://www.shelly.cloud/en/products/shop/shelly-plus-1-mini
+[Mini1G3]: https://www.shelly.cloud/en/products/shop/shelly-1-mini-gen-3
+[Mini1PMG3]: https://www.shelly.cloud/en/products/shop/shelly-1-pm-mini-gen3
 [+1PM]: https://www.shelly.cloud/en/products/shop/shelly-plus-1-pm-2-pack/shelly-plus-1-pm
 [+2PM]: https://www.shelly.cloud/en/products/shop/shelly-plus-2-pm
 [+RGBWPM]: https://www.shelly.cloud/en/products/shop/shelly-plus-rgbw-pm

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Reverting to stock firmware is also possible [see here](https://github.com/mongo
 
 ### Gen 3 Devices
 
-Currently not supported.
+|                                            |[Mini1G3]|[Mini1PMG3]
+|-                                           |-        |-          
+|Switch & Co.<sup>1</sup>                    |✓        |✓          
+|Stateless Input<sup>2</sup>                 |✓        |✓          
+|Garage door opener                          |✓        |✓          
+|Power measurement                           |✗        |-
 
 ### Plus devices
 

--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -425,14 +425,8 @@
         href="https://github.com/mongoose-os-apps/shelly-homekit/blob/master/AUTHORS.md">Shelly-HomeKit
         contributors</a>.
       <br>Use <a href="https://github.com/mongoose-os-apps/shelly-homekit/issues">GitHub</a> to report bugs and
-      request features.
+      request features. If you like the firmware consider a <a href="https://github.com/mongoose-os-apps/shelly-homekit?tab=readme-ov-file#support">Donation</a>.
       <br>
-      <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-        <input type="hidden" name="cmd" value="_s-xclick" />
-        <input type="hidden" name="hosted_button_id" value="6KPSKWJDHVLB4" />
-        <input type="image" id="donate_form_submit" border="0" name="submit" title="Donate via PayPal"
-          alt="Donate via PayPal" style="display: none" />
-      </form>
     </div>
   </div>
 

--- a/mos.yml
+++ b/mos.yml
@@ -684,9 +684,9 @@ conds:
         - ["in4.ssw.name", "Shelly SSW4"]
         - ["in4.sensor.name", "Shelly S4"]
 
-  - when: build_vars.MODEL == "ShellyMini1Gen3"
+  - when: build_vars.MODEL == "ShellyMini1PMGen3"
     apply:
-      name: Mini1G3
+      name: Mini1PMG3
       libs:
         - location: https://github.com/mongoose-os-libs/mongoose
       build_vars:
@@ -697,7 +697,6 @@ conds:
         APP_OFFSET: 0x20000
         APP_SLOT_SIZE: 0x280000
         MGOS_ROOT_FS_TYPE: LFS
-          #MGOS_ROOT_FS_SIZE: 10485762
         MGOS_ROOT_FS_SIZE: 1048576
         ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x720000,0x80000,encrypted"
         ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x7F0000,64K,encrypted"
@@ -711,7 +710,49 @@ conds:
         LED_ON: 0
         BTN_GPIO: 1
         BTN_DOWN: 0
-        PRODUCT_HW_REV: "0.1.6"
+        PRODUCT_HW_REV: "0.1.0"
+        STOCK_FW_MODEL: Mini1PMG3
+        MAX_NUM_HAP_SESSIONS: 16
+      config_schema:
+        - ["device.id", "ShellyMini1G3-??????"]
+        - ["shelly.name", "ShellyMini1G3-??????"]
+        - ["wifi.ap.ssid", "ShellyMini1G3-??????"]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Shelly SW"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Shelly SSW1"]
+        - ["in1.sensor.name", "Shelly S1"]
+        - ["gdo1", "gdo", {title: "GDO1 settings"}]
+        - ["gdo1.name", "Garage Door"]
+        - ["gdo1.open_sensor_mode", 2]
+
+  - when: build_vars.MODEL == "ShellyMini1Gen3"
+    apply:
+      name: Mini1G3
+      libs:
+        - location: https://github.com/mongoose-os-libs/mongoose
+      build_vars:
+        OTA_DATA_ADDR: 0x10000
+        OTA_DATA_SIZE: 0x4000
+        NVS_ADDR: 0x14000
+        NVS_SIZE: 0xC000
+        APP_OFFSET: 0x20000
+        APP_SLOT_SIZE: 0x280000
+        MGOS_ROOT_FS_TYPE: LFS
+        MGOS_ROOT_FS_SIZE: 1048576
+        ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x720000,0x80000,encrypted"
+        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x7F0000,64K,encrypted"
+        ESP_IDF_SDKCONFIG_OPTS: >
+          ${build_vars.ESP_IDF_SDKCONFIG_OPTS}
+            CONFIG_FREERTOS_UNICORE=y
+            CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+            CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+      cdefs:
+        LED_GPIO: 0
+        LED_ON: 0
+        BTN_GPIO: 1
+        BTN_DOWN: 0
+        PRODUCT_HW_REV: "0.1.0"
         STOCK_FW_MODEL: Mini1G3
         MAX_NUM_HAP_SESSIONS: 16
       config_schema:

--- a/mos.yml
+++ b/mos.yml
@@ -768,6 +768,46 @@ conds:
         - ["gdo1.name", "Garage Door"]
         - ["gdo1.open_sensor_mode", 2]
 
+  - when: build_vars.MODEL == "ShellyPlus1Mini"
+    apply:
+      name: Plus1Mini
+      sources:
+        - src/ShellyMini1Gen3
+      libs:
+        - location: https://github.com/mongoose-os-libs/mongoose
+      build_vars:
+        MGOS_ROOT_FS_TYPE: LFS
+        MGOS_ROOT_FS_SIZE: 458752
+        ESP_IDF_EXTRA_PARTITION: "aux,0x55,0x00,0x3f0000,48K"
+        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x3fc000,16K,encrypted"
+        ESP_IDF_SDKCONFIG_OPTS: >
+          ${build_vars.ESP_IDF_SDKCONFIG_OPTS}
+            CONFIG_FREERTOS_UNICORE=y
+            CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+      cdefs:
+        LED_GPIO: 0
+        LED_ON: 0
+        BTN_GPIO: 1
+        BTN_DOWN: 0
+        PRODUCT_HW_REV: "0.1.6"
+        STOCK_FW_MODEL: Plus1Mini
+        MAX_NUM_HAP_SESSIONS: 16
+      config_schema:
+        - ["device.id", "ShellyPlus1Mini-??????"]
+        - ["shelly.name", "ShellyPlus1Mini-??????"]
+        - ["wifi.ap.ssid", "ShellyPlus1Mini-??????"]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Shelly SW"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Shelly SSW1"]
+        - ["in1.sensor.name", "Shelly S1"]
+        - ["in2", "in", {title: "Input 2 settings"}]
+        - ["in2.ssw.name", "Shelly SSW2"]
+        - ["in2.sensor.name", "Shelly S2"]
+        - ["gdo1", "gdo", {title: "GDO1 settings"}]
+        - ["gdo1.name", "Garage Door"]
+        - ["gdo1.open_sensor_mode", 2]
+
   - when: build_vars.MODEL == "ShellyPlus1"
     apply:
       name: Plus1

--- a/mos.yml
+++ b/mos.yml
@@ -615,7 +615,6 @@ conds:
         - ["bl0937.power_coeff", "f", 0, {title: "BL0937 counts -> watts conversion coefficient"}]
         - ["bl0937.power_coeff", 1.64358469]  # (16 + 1010 + 1935) / (9.55 + 617 + 1175)
 
-
   - when: build_vars.MODEL == "ShellyPlusRGBWPM"
     apply:
       name: PlusRGBWPM
@@ -670,6 +669,44 @@ conds:
         - ["in4", "in", {title: "Input 4 settings"}]
         - ["in4.ssw.name", "Shelly SSW4"]
         - ["in4.sensor.name", "Shelly S4"]
+
+  - when: build_vars.MODEL == "ShellyMini1Gen3"
+    apply:
+      name: Mini1G3
+      libs:
+        - location: https://github.com/mongoose-os-libs/mongoose
+      build_vars:
+        MGOS_ROOT_FS_TYPE: LFS
+        MGOS_ROOT_FS_SIZE: 458752
+        ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x3f0000,48K"
+        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x3fc000,16K,encrypted"
+        #MGOS_ROOT_FS_SIZE: 10458752
+        #ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x720000,832K"
+        #ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x7F0000,64K,encrypted"
+        ESP_IDF_SDKCONFIG_OPTS: >
+          ${build_vars.ESP_IDF_SDKCONFIG_OPTS}
+            CONFIG_FREERTOS_UNICORE=y
+            CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+      cdefs:
+        LED_GPIO: 0
+        LED_ON: 0
+        BTN_GPIO: 1
+        BTN_DOWN: 0
+        PRODUCT_HW_REV: "0.1.6"
+        STOCK_FW_MODEL: Mini1G3
+        MAX_NUM_HAP_SESSIONS: 16
+      config_schema:
+        - ["device.id", "ShellyMini1G3-??????"]
+        - ["shelly.name", "ShellyMini1G3-??????"]
+        - ["wifi.ap.ssid", "ShellyMini1G3-??????"]
+        - ["sw1", "sw", {title: "SW1 settings"}]
+        - ["sw1.name", "Shelly SW"]
+        - ["in1", "in", {title: "Input 1 settings"}]
+        - ["in1.ssw.name", "Shelly SSW1"]
+        - ["in1.sensor.name", "Shelly S1"]
+        - ["gdo1", "gdo", {title: "GDO1 settings"}]
+        - ["gdo1.name", "Garage Door"]
+        - ["gdo1.open_sensor_mode", 2]
 
   - when: build_vars.MODEL == "ShellyPlus1"
     apply:

--- a/mos.yml
+++ b/mos.yml
@@ -169,6 +169,10 @@ libs:
   # - location: https://github.com/mongoose-os-libs/rpc-service-ota
 
 conds:
+  - when: mos.platform == "esp32c3"
+    apply:
+      libs:
+        - location: https://github.com/markirb/adc
   - when: mos.platform == "esp32"
     apply:
       libs:

--- a/mos.yml
+++ b/mos.yml
@@ -169,6 +169,18 @@ libs:
   # - location: https://github.com/mongoose-os-libs/rpc-service-ota
 
 conds:
+  - when: mos.platform == "esp32"
+    apply:
+      libs:
+        - location: https://github.com/mongoose-os-libs/adc
+        - location: https://github.com/mongoose-os-libs/pwm
+
+  - when: mos.platform == "esp8266"
+    apply:
+      libs:
+        - location: https://github.com/mongoose-os-libs/adc
+        - location: https://github.com/mongoose-os-libs/pwm
+
   - when: mos.platform != "ubuntu"
     apply:
       sources:
@@ -189,8 +201,6 @@ conds:
         # Consider removing in later releases.
         - ["shelly.wifi_connect_reboot_timeout", "i", 0, {title: "If not connected for this long when supposed to be, reboot"}]
       libs:
-        - location: https://github.com/mongoose-os-libs/adc
-        - location: https://github.com/mongoose-os-libs/pwm
         - location: https://github.com/mongoose-os-libs/wifi
       cdefs:
         # Size fine-tuning, saves substantial amount of RAM vs defaults.
@@ -676,17 +686,22 @@ conds:
       libs:
         - location: https://github.com/mongoose-os-libs/mongoose
       build_vars:
+        OTA_DATA_ADDR: 0x10000
+        OTA_DATA_SIZE: 0x4000
+        NVS_ADDR: 0x14000
+        NVS_SIZE: 0xC000
+        APP_OFFSET: 0x20000
+        APP_SLOT_SIZE: 0x280000
         MGOS_ROOT_FS_TYPE: LFS
-        MGOS_ROOT_FS_SIZE: 458752
-        ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x3f0000,48K"
-        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x3fc000,16K,encrypted"
-        #MGOS_ROOT_FS_SIZE: 10458752
-        #ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x720000,832K"
-        #ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x7F0000,64K,encrypted"
+          #MGOS_ROOT_FS_SIZE: 10485762
+        MGOS_ROOT_FS_SIZE: 1048576
+        ESP_IDF_EXTRA_PARTITION: "scratch,data,0x80,0x720000,0x80000,encrypted"
+        ESP_IDF_EXTRA_PARTITION_2: "shelly,data,0x88,0x7F0000,64K,encrypted"
         ESP_IDF_SDKCONFIG_OPTS: >
           ${build_vars.ESP_IDF_SDKCONFIG_OPTS}
             CONFIG_FREERTOS_UNICORE=y
             CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+            CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
       cdefs:
         LED_GPIO: 0
         LED_ON: 0

--- a/src/ShellyMini1Gen3/shelly_init.cpp
+++ b/src/ShellyMini1Gen3/shelly_init.cpp
@@ -33,7 +33,11 @@ void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
   in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
   in->Init();
   inputs->emplace_back(in);
+
+// not yet compatible
+#ifdef MGOS_HAVE_ADC
   sys_temp->reset(new TempSensorSDNT1608X103F3950(3, 3.3f, 10000.0f));
+#endif
 
   InitSysLED(LED_GPIO, LED_ON);
   InitSysBtn(BTN_GPIO, BTN_DOWN);

--- a/src/ShellyMini1Gen3/shelly_init.cpp
+++ b/src/ShellyMini1Gen3/shelly_init.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_hap_input.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+#include "shelly_sys_led_btn.hpp"
+#include "shelly_temp_sensor_ntc.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       std::vector<std::unique_ptr<PowerMeter>> *pms UNUSED_ARG,
+                       std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 7, 1));
+  auto *in = new InputPin(1, 10, 1, MGOS_GPIO_PULL_NONE, true);
+  in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
+  in->Init();
+  inputs->emplace_back(in);
+  sys_temp->reset(new TempSensorSDNT1608X103F3950(3, 3.3f, 10000.0f));
+
+  InitSysLED(LED_GPIO, LED_ON);
+  InitSysBtn(BTN_GPIO, BTN_DOWN);
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  bool gdo_mode = mgos_sys_config_get_shelly_mode() == (int) Mode::kGarageDoor;
+  if (gdo_mode) {
+    hap::CreateHAPGDO(1, FindInput(1), FindInput(2), FindOutput(1),
+                      FindOutput(1), mgos_sys_config_get_gdo1(), comps, accs,
+                      svr, true);
+  } else {
+    CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                    comps, accs, svr, true);
+  }
+}
+
+}  // namespace shelly

--- a/src/ShellyMini1PMGen3/shelly_init.cpp
+++ b/src/ShellyMini1PMGen3/shelly_init.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Shelly-HomeKit Contributors
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shelly_hap_garage_door_opener.hpp"
+#include "shelly_hap_input.hpp"
+#include "shelly_input_pin.hpp"
+#include "shelly_main.hpp"
+#include "shelly_sys_led_btn.hpp"
+#include "shelly_temp_sensor_ntc.hpp"
+
+namespace shelly {
+
+void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
+                       std::vector<std::unique_ptr<Output>> *outputs,
+                       std::vector<std::unique_ptr<PowerMeter>> *pms UNUSED_ARG,
+                       std::unique_ptr<TempSensor> *sys_temp) {
+  outputs->emplace_back(new OutputPin(1, 5, 1));
+  auto *in = new InputPin(1, 10, 1, MGOS_GPIO_PULL_NONE, true);
+  in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
+  in->Init();
+  inputs->emplace_back(in);
+
+// not yet compatible
+#ifdef MGOS_HAVE_ADC
+  sys_temp->reset(new TempSensorSDNT1608X103F3950(3, 3.3f, 10000.0f));
+#endif
+
+  // std::unique_ptr<PowerMeter> pm()
+  // BL0942 GPIO6 TX GPIO7 RX
+  // const Status &st = pm->Init();
+  // if (st.ok()) {
+  //   pms->emplace_back(std::move(pm));
+  // } else {
+  //   const std::string &s = st.ToString();
+  //   LOG(LL_ERROR, ("PM init failed: %s", s.c_str()));
+  // }
+
+  InitSysLED(LED_GPIO, LED_ON);
+  InitSysBtn(BTN_GPIO, BTN_DOWN);
+}
+
+void CreateComponents(std::vector<std::unique_ptr<Component>> *comps,
+                      std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
+                      HAPAccessoryServerRef *svr) {
+  bool gdo_mode = mgos_sys_config_get_shelly_mode() == (int) Mode::kGarageDoor;
+  if (gdo_mode) {
+    hap::CreateHAPGDO(1, FindInput(1), FindInput(2), FindOutput(1),
+                      FindOutput(1), mgos_sys_config_get_gdo1(), comps, accs,
+                      svr, true);
+  } else {
+    CreateHAPSwitch(1, mgos_sys_config_get_sw1(), mgos_sys_config_get_in1(),
+                    comps, accs, svr, true);
+  }
+}
+
+}  // namespace shelly

--- a/src/shelly_output.cpp
+++ b/src/shelly_output.cpp
@@ -19,7 +19,10 @@
 
 #include "mgos.hpp"
 #include "mgos_gpio.h"
+
+#ifdef MGOS_HAVE_PWM
 #include "mgos_pwm.h"
+#endif
 
 namespace shelly {
 
@@ -66,6 +69,7 @@ Status OutputPin::SetState(bool on, const char *source) {
 }
 
 Status OutputPin::SetStatePWM(float duty, const char *source) {
+#ifdef MGOS_HAVE_PWM
   LOG(LL_INFO, ("Duty: %.3f", duty));
   if (duty == 0) {
     mgos_pwm_set(pin_, 0, 0);
@@ -78,6 +82,9 @@ Status OutputPin::SetStatePWM(float duty, const char *source) {
     LOG(LL_INFO, ("Output %d: %f (%s)", id(), duty, source));
   }
   return Status::OK();
+#else
+  return Status::UNIMPLEMENTED();
+#endif
 }
 
 Status OutputPin::Pulse(bool on, int duration_ms, const char *source) {


### PR DESCRIPTION
TODOS:

- [x] Temp sensor
- [x] Crypto acceleration (hardware MPI)
- [x] In/Output verification
- [x] verify downgrade working  (non PM)

PM support for BL0942 (will be done in separate PR cannot be done without HW available)