### PR TITLE
Fix Mini 1 Gen 3 Relais After update

### DIFF
--- a/src/ShellyMini1Gen3/shelly_init.cpp
+++ b/src/ShellyMini1Gen3/shelly_init.cpp
@@ -22,6 +22,8 @@
 #include "shelly_sys_led_btn.hpp"
 #include "shelly_temp_sensor_ntc.hpp"
 
+#include "driver/gpio.h"
+
 namespace shelly {
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
@@ -29,6 +31,9 @@ void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms UNUSED_ARG,
                        std::unique_ptr<TempSensor> *sys_temp) {
   outputs->emplace_back(new OutputPin(1, 7, 1));
+
+  gpio_hold_dis(GPIO_NUM_7);
+
   auto *in = new InputPin(1, 10, 1, MGOS_GPIO_PULL_NONE, true);
   in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
   in->Init();

--- a/src/ShellyMini1PMGen3/shelly_init.cpp
+++ b/src/ShellyMini1PMGen3/shelly_init.cpp
@@ -22,6 +22,8 @@
 #include "shelly_sys_led_btn.hpp"
 #include "shelly_temp_sensor_ntc.hpp"
 
+#include "driver/gpio.h"
+
 namespace shelly {
 
 void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
@@ -29,6 +31,9 @@ void CreatePeripherals(std::vector<std::unique_ptr<Input>> *inputs,
                        std::vector<std::unique_ptr<PowerMeter>> *pms UNUSED_ARG,
                        std::unique_ptr<TempSensor> *sys_temp) {
   outputs->emplace_back(new OutputPin(1, 5, 1));
+
+  gpio_hold_dis(GPIO_NUM_5);
+
   auto *in = new InputPin(1, 10, 1, MGOS_GPIO_PULL_NONE, true);
   in->AddHandler(std::bind(&HandleInputResetSequence, in, LED_GPIO, _1, _2));
   in->Init();


### PR DESCRIPTION
To check: if this affects also esp32 devices on newer FWs

include all other GEN3