### PR TITLE
Add manual calibration mode for roller shutter

### DIFF
--- a/fs_src/index.html
+++ b/fs_src/index.html
@@ -739,6 +739,17 @@
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="form-control">
+            <label>Manual Calibration:</label>
+            <label class="switch">
+              <input type="checkbox" id="man_cal">
+              <span class="slider round"></span>
+            </label>
+          </div>
+          <div class="form-control" id="man_cal_time_container" style="display: none">
+            <label>Movement Time (ms):</label>
+            <input type="number" id="man_cal_time" style="width: 5em; min-width: 5em" min="1000" max="300000">
+          </div>
           <div class="button-container" id="btns">
             <button id="save_btn">
               <label><span id="save_spinner"></span>Save</label>

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -596,11 +596,12 @@ function findOrAddContainer(cd) {
         setComponentState(c, {state: 10}, null);
         el(c, "cal_spinner").className = "spin";
       };
-      el(c, "man_cal").onchange = function() {
+      el(c, "man_cal").onchange = function(ev) {
         el(c, "man_cal_time_container").style.display =
             el(c, "man_cal").checked ? "block" : "none";
         el(c, "cal_btn").style.display =
             el(c, "man_cal").checked ? "none" : "";
+        markInputChanged(ev);
       };
       break;
     case Component_Type.kGarageDoorOpener:
@@ -858,7 +859,7 @@ function updateComponent(cd) {
       checkIfNotModified(el(c, "swap_inputs"), cd.swap_inputs);
       checkIfNotModified(el(c, "swap_outputs"), cd.swap_outputs);
       checkIfNotModified(el(c, "man_cal"), cd.man_cal);
-      let isManCal = cd.man_cal == 1;
+      let isManCal = el(c, "man_cal").checked;
       el(c, "man_cal_time_container").style.display =
           isManCal ? "block" : "none";
       el(c, "cal_btn").style.display = isManCal ? "none" : "";

--- a/fs_src/script.js
+++ b/fs_src/script.js
@@ -468,13 +468,25 @@ function wcSetConfig(c, cfg, spinner) {
       alert("Name must not be empty");
       return;
     }
+    let manCal = el(c, "man_cal").checked;
+    let moveTimeMs = parseInt(el(c, "man_cal_time").value);
+    if (manCal) {
+      if (isNaN(moveTimeMs) || moveTimeMs < 1000 || moveTimeMs > 300000) {
+        alert("Movement time must be between 1000 and 300000 ms");
+        return;
+      }
+    }
     cfg = {
       name: name,
       display_type: parseInt(el(c, "display_type").value),
       in_mode: parseInt(el(c, "in_mode").value),
       swap_inputs: el(c, "swap_inputs").checked,
       swap_outputs: el(c, "swap_outputs").checked,
+      man_cal: manCal,
     };
+    if (manCal) {
+      cfg.move_time_ms = moveTimeMs;
+    }
   }
   setComponentConfig(c, cfg, spinner);
 }
@@ -583,6 +595,12 @@ function findOrAddContainer(cd) {
       el(c, "cal_btn").onclick = function() {
         setComponentState(c, {state: 10}, null);
         el(c, "cal_spinner").className = "spin";
+      };
+      el(c, "man_cal").onchange = function() {
+        el(c, "man_cal_time_container").style.display =
+            el(c, "man_cal").checked ? "block" : "none";
+        el(c, "cal_btn").style.display =
+            el(c, "man_cal").checked ? "none" : "";
       };
       break;
     case Component_Type.kGarageDoorOpener:
@@ -839,8 +857,24 @@ function updateComponent(cd) {
       selectIfNotModified(el(c, "in_mode"), cd.in_mode);
       checkIfNotModified(el(c, "swap_inputs"), cd.swap_inputs);
       checkIfNotModified(el(c, "swap_outputs"), cd.swap_outputs);
+      checkIfNotModified(el(c, "man_cal"), cd.man_cal);
+      let isManCal = cd.man_cal == 1;
+      el(c, "man_cal_time_container").style.display =
+          isManCal ? "block" : "none";
+      el(c, "cal_btn").style.display = isManCal ? "none" : "";
+      if (isManCal) {
+        setValueIfNotModified(el(c, "man_cal_time"), cd.move_time_ms);
+      }
       let posText, calText;
-      if (cd.cal_done == 1) {
+      if (isManCal && cd.move_time_ms > 0) {
+        if (cd.cur_pos != cd.tgt_pos) {
+          posText = `${cd.cur_pos} -> ${cd.tgt_pos}`;
+        } else {
+          posText = cd.cur_pos;
+        }
+        calText = `manual: ${cd.move_time_ms / 1000} s`;
+        el(c, "pos_ctl").style.display = "block";
+      } else if (cd.cal_done == 1) {
         if (cd.cur_pos != cd.tgt_pos) {
           posText = `${cd.cur_pos} -> ${cd.tgt_pos}`;
         } else {
@@ -1613,6 +1647,7 @@ function resetLastSetValue() {
 }
 
 function updateInnerText(e, newInnerText) {
+  if (e === null || newInnerText === null || newInnerText === undefined) return;
   newInnerText = newInnerText.toString();
   if (e.innerText === newInnerText) return;
   e.innerText = newInnerText;

--- a/mos.yml
+++ b/mos.yml
@@ -77,6 +77,7 @@ config_schema:
   - ["wc.swap_inputs", "b", false, {title: "Swap inputs (2 - open, 1 - close)"}]
   - ["wc.swap_outputs", "b", false, {title: "Swap outputs (2 - open, 1 - close)"}]
   - ["wc.calibrated", "b", false, {title: "Calibration done"}]
+  - ["wc.man_cal", "b", false, {title: "Manual calibration mode"}]
   - ["wc.idle_power_thr", "f", 5.0, {title: "Power consumption threshold for motor idle detection"}]
   - ["wc.move_power", "f", 0.0, {title: "Power consumption during movement, watts"}]
   - ["wc.move_time_ms", "i", 0, {title: "Move time, in millseconds"}]
@@ -1786,6 +1787,8 @@ conds:
 
   - when: build_vars.MODEL == "ShellyU"
     apply:
+      includes:
+        - src/mock
       sources:
         - src/mock/pwm
         - src/mock/wifi_config
@@ -1817,6 +1820,8 @@ conds:
 
   - when: build_vars.MODEL == "ShellyUDuo"
     apply:
+      includes:
+        - src/mock
       sources:
         - src/ShellyDuo/shelly_init.cpp
         - src/mock/pwm
@@ -1839,6 +1844,8 @@ conds:
 
   - when: build_vars.MODEL == "ShellyU25"
     apply:
+      includes:
+        - src/mock
       sources:
         - src/Shelly25/shelly_init_components.cpp  # Same components as Shelly25
         - src/mock/pwm
@@ -1873,6 +1880,8 @@ conds:
 
   - when: build_vars.MODEL == "ShellyURGBW2"
     apply:
+      includes:
+        - src/mock
       sources:
         - src/ShellyRGBW2/shelly_init.cpp  # Same components as ShellyRGBW2
         - src/mock/pwm

--- a/src/mock/driver/gpio.h
+++ b/src/mock/driver/gpio.h
@@ -1,0 +1,14 @@
+// Mock driver/gpio.h for Ubuntu build
+#pragma once
+
+typedef int gpio_num_t;
+
+static inline int gpio_hold_en(gpio_num_t gpio_num) {
+  (void) gpio_num;
+  return 0;
+}
+
+static inline int gpio_hold_dis(gpio_num_t gpio_num) {
+  (void) gpio_num;
+  return 0;
+}

--- a/src/shelly_hap_window_covering.cpp
+++ b/src/shelly_hap_window_covering.cpp
@@ -172,7 +172,10 @@ Status WindowCovering::Init() {
     case InMode::kDetached:
       break;
   }
-  if (cfg_->calibrated) {
+  if (cfg_->man_cal) {
+    LOG(LL_INFO, ("WC %d: manual cal, mt_ms %d, cur_pos %.2f", id(),
+                  cfg_->move_time_ms, cur_pos_));
+  } else if (cfg_->calibrated) {
     LOG(LL_INFO, ("WC %d: mp %.2f, mt_ms %d, cur_pos %.2f", id(),
                   cfg_->move_power, cfg_->move_time_ms, cur_pos_));
   } else {
@@ -202,11 +205,11 @@ StatusOr<std::string> WindowCovering::GetInfoJSON() const {
   return mgos::JSONPrintStringf(
       "{id: %d, type: %d, name: %Q, "
       "in_mode: %d, swap_inputs: %B, swap_outputs: %B, "
-      "cal_done: %B, move_time_ms: %d, move_power: %d, "
+      "cal_done: %B, man_cal: %B, move_time_ms: %d, move_power: %d, "
       "state: %d, state_str: %Q, cur_pos: %d, tgt_pos: %d, "
       "display_type: %d}",
       id(), type(), cfg_->name, cfg_->in_mode, cfg_->swap_inputs,
-      cfg_->swap_outputs, cfg_->calibrated, cfg_->move_time_ms,
+      cfg_->swap_outputs, cfg_->calibrated, cfg_->man_cal, cfg_->move_time_ms,
       (int) cfg_->move_power, (int) state_, StateStr(state_), (int) cur_pos_,
       (int) tgt_pos_, (int) service_type_);
 }
@@ -217,11 +220,14 @@ Status WindowCovering::SetConfig(const std::string &config_json,
   cfg.name = nullptr;
   int in_mode = -1;
   int8_t swap_inputs = -1, swap_outputs = -1;
+  int8_t man_cal = -1;
+  int move_time_ms = -1;
   int display_type = -1;
   json_scanf(config_json.c_str(), config_json.size(),
              "{name: %Q, in_mode: %d, swap_inputs: %B, swap_outputs: %B, "
-             "display_type: %d}",
-             &cfg.name, &in_mode, &swap_inputs, &swap_outputs, &display_type);
+             "display_type: %d, man_cal: %B, move_time_ms: %d}",
+             &cfg.name, &in_mode, &swap_inputs, &swap_outputs, &display_type,
+             &man_cal, &move_time_ms);
   mgos::ScopedCPtr name_owner((void *) cfg.name);
   // Validate.
   if (cfg.name != nullptr && strlen(cfg.name) > 64) {
@@ -258,6 +264,18 @@ Status WindowCovering::SetConfig(const std::string &config_json,
     service_type_ = static_cast<ServiceType>(display_type);
     cfg_->display_type = display_type;
     *restart_required = true;
+  }
+  if (man_cal != -1 && man_cal != cfg_->man_cal) {
+    cfg_->man_cal = man_cal;
+    if (man_cal && move_time_ms > 0) {
+      cfg_->move_time_ms = move_time_ms;
+      move_ms_per_pct_ = cfg_->move_time_ms / 100.0;
+    }
+    *restart_required = true;
+  } else if (move_time_ms > 0 && move_time_ms != cfg_->move_time_ms &&
+             cfg_->man_cal) {
+    cfg_->move_time_ms = move_time_ms;
+    move_ms_per_pct_ = cfg_->move_time_ms / 100.0;
   }
   return Status::OK();
 }
@@ -410,7 +428,9 @@ void WindowCovering::HAPSetTgtPos(float value) {
 WindowCovering::Direction WindowCovering::GetDesiredMoveDirection() {
   if (tgt_pos_ == kNotSet) return Direction::kNone;
   float pos_diff = tgt_pos_ - cur_pos_;
-  if (!cfg_->calibrated || std::abs(pos_diff) < 0.5) {
+  bool can_move = cfg_->calibrated ||
+                  (cfg_->man_cal && cfg_->move_time_ms > 0);
+  if (!can_move || std::abs(pos_diff) < 0.5) {
     return Direction::kNone;
   }
   return (pos_diff > 0 ? Direction::kOpen : Direction::kClose);
@@ -419,7 +439,7 @@ WindowCovering::Direction WindowCovering::GetDesiredMoveDirection() {
 void WindowCovering::Move(Direction dir) {
   const char *ss = StateStr(state_);
   bool want_open = false, want_close = false;
-  if (cfg_->calibrated) {
+  if (cfg_->calibrated || cfg_->man_cal) {
     switch (dir) {
       case Direction::kNone:
         break;
@@ -553,6 +573,11 @@ void WindowCovering::RunOnce() {
       break;
     }
     case State::kRampUp: {
+      if (cfg_->man_cal) {
+        // Manual cal: skip power ramp-up check, go straight to moving.
+        SetInternalState(State::kMoving);
+        break;
+      }
       auto *pm = (moving_dir_ == Direction::kOpen ? pm_open_ : pm_close_);
       auto pmv = pm->GetPowerW();
       float p = -1;
@@ -584,9 +609,37 @@ void WindowCovering::RunOnce() {
       float new_cur_pos =
           (moving_dir_ == Direction::kOpen ? move_start_pos_ + pos_diff
                                            : move_start_pos_ - pos_diff);
+      float p = -1;
+      if (cfg_->man_cal) {
+        // Manual cal: time-based position tracking only, no power monitoring.
+        p = 0;
+        SetCurPos(new_cur_pos, p);
+        Direction want_move_dir = GetDesiredMoveDirection();
+        bool reverse =
+            (want_move_dir != moving_dir_ && want_move_dir != Direction::kNone);
+        // At limit positions, stop after full move_time_ms.
+        if (((tgt_pos_ == kFullyOpen && moving_dir_ == Direction::kOpen) ||
+             (tgt_pos_ == kFullyClosed && moving_dir_ == Direction::kClose)) &&
+            !reverse) {
+          if (moving_time_ms < cfg_->move_time_ms) {
+            break;  // Still moving.
+          }
+          float pos =
+              (moving_dir_ == Direction::kOpen ? kFullyOpen : kFullyClosed);
+          SetCurPos(pos, p);
+        } else if (want_move_dir == moving_dir_) {
+          break;  // Still moving.
+        } else {
+          if (std::abs(tgt_pos_ - cur_pos_) < 1) {
+            SetTgtPos(cur_pos_, "fixup");
+          }
+        }
+        Move(Direction::kNone);
+        SetInternalState(State::kStop);
+        break;
+      }
       auto *pm = (moving_dir_ == Direction::kOpen ? pm_open_ : pm_close_);
       auto pmv = pm->GetPowerW();
-      float p = -1;
       if (pmv.ok()) {
         p = pmv.ValueOrDie();
       } else {
@@ -651,6 +704,11 @@ void WindowCovering::RunOnce() {
       break;
     }
     case State::kStopping: {
+      if (cfg_->man_cal) {
+        // Manual cal: no power monitoring, transition immediately.
+        SetInternalState(State::kIdle);
+        break;
+      }
       float p0 = 0, p1 = 0;
       auto p0v = pm_open_->GetPowerW();
       if (p0v.ok()) p0 = p0v.ValueOrDie();
@@ -672,7 +730,7 @@ void WindowCovering::RunOnce() {
 
 void WindowCovering::HandleInputEvent01(Direction dir, Input::Event ev,
                                         bool state) {
-  if (!cfg_->calibrated) {
+  if (!cfg_->calibrated && !cfg_->man_cal) {
     HandleInputEventNotCalibrated();
     return;
   }
@@ -700,7 +758,7 @@ void WindowCovering::HandleInputEvent01(Direction dir, Input::Event ev,
 }
 
 void WindowCovering::HandleInputEvent2(Input::Event ev, bool state) {
-  if (!cfg_->calibrated) {
+  if (!cfg_->calibrated && !cfg_->man_cal) {
     HandleInputEventNotCalibrated();
     return;
   }


### PR DESCRIPTION
## Motivation
I'm using a Shelly 2.5 to control a **Dooya smart curtain motor** which has a dedicated motor phase — the existing power-consumption-based automatic calibration doesn't work for this setup. This PR adds a manual calibration mode so users can simply specify the movement time directly.

## Summary
- **Manual Calibration mode** for Window Covering (roller shutter): allows users to set movement time manually instead of relying on automatic calibration
- Useful for motors where auto-calibration doesn't work (e.g. Dooya curtain motors with dedicated phase, or any setup without reliable power measurement / idle detection)
- **Fix Ubuntu (ShellyU) emulator build**: added missing mock `driver/gpio.h` and include paths for all ShellyU variants

## Changes
- `mos.yml`: new `wc.man_cal` config field + ShellyU include path fixes
- `src/shelly_hap_window_covering.cpp`: manual cal support in `SetConfig`, `Init`, `GetInfoJSON`, `GetDesiredMoveDirection`
- `fs_src/index.html`: Manual Calibration toggle + Movement Time (ms) input field
- `fs_src/script.js`: UI logic for toggle, save, status display (`manual: X s`), and null guard fix in `updateInnerText`
- `src/mock/driver/gpio.h`: mock GPIO header for Ubuntu build

## How it works
1. In the Web UI, enable "Manual Calibration" toggle under Window Covering settings
2. Enter the total movement time in milliseconds (1000–300000)
3. Click Save — calibration status shows `manual: X s`
4. Open/Close buttons appear for position control
5. The auto-calibrate button is hidden when manual cal is active

## Test plan
- [x] Built successfully: ShellyU25 (emulator) and Shelly25 (real hardware fw)
- [x] Tested Web UI with mock server (Playwright)
- [x] Tested with real firmware in Docker emulator (ShellyU25)
- [x] Verified RPC `Shelly.SetConfig` sends `man_cal` and `move_time_ms` correctly
- [x] Verified firmware log: `WC 1: manual cal, mt_ms 20000, cur_pos 0.00`
