### PR TITLE
Show lock tile in doorbell notification

### DIFF
--- a/src/shelly_hap_input.cpp
+++ b/src/shelly_hap_input.cpp
@@ -275,7 +275,8 @@ bool ShellyInput::IsValidType(int type) {
 void CreateHAPInput(int id, const struct mgos_config_in *cfg,
                     std::vector<std::unique_ptr<Component>> *comps,
                     std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
-                    HAPAccessoryServerRef *svr) {
+                    HAPAccessoryServerRef *svr,
+                    mgos::hap::Accessory *existing_acc) {
   Input *in = FindInput(id);
   if (in == nullptr) return;
   std::unique_ptr<ShellyInput> sin(
@@ -287,12 +288,16 @@ void CreateHAPInput(int id, const struct mgos_config_in *cfg,
     return;
   }
   if (sin->GetService() != nullptr) {
-    std::unique_ptr<mgos::hap::Accessory> acc(new mgos::hap::Accessory(
-        sin->GetAIDBase() + id, kHAPAccessoryCategory_BridgedAccessory,
-        sin->name(), GetIdentifyCB(), svr));
-    acc->AddHAPService(&mgos_hap_accessory_information_service);
-    acc->AddService(sin->GetService());
-    accs->push_back(std::move(acc));
+    if (existing_acc != nullptr) {
+      existing_acc->AddService(sin->GetService());
+    } else {
+      std::unique_ptr<mgos::hap::Accessory> acc(new mgos::hap::Accessory(
+          sin->GetAIDBase() + id, kHAPAccessoryCategory_BridgedAccessory,
+          sin->name(), GetIdentifyCB(), svr));
+      acc->AddHAPService(&mgos_hap_accessory_information_service);
+      acc->AddService(sin->GetService());
+      accs->push_back(std::move(acc));
+    }
   }
   comps->push_back(std::move(sin));
 }

--- a/src/shelly_hap_input.hpp
+++ b/src/shelly_hap_input.hpp
@@ -64,10 +64,14 @@ class ShellyInput : public Component {
   ShellyInput(const ShellyInput &other) = delete;
 };
 
+// If existing_acc is non-null, the input service is added to it instead of
+// creating a new accessory. Used to combine doorbell + lock on the same
+// accessory so iOS shows the lock tile in the doorbell notification.
 void CreateHAPInput(int id, const struct mgos_config_in *cfg,
                     std::vector<std::unique_ptr<Component>> *comps,
                     std::vector<std::unique_ptr<mgos::hap::Accessory>> *accs,
-                    HAPAccessoryServerRef *svr);
+                    HAPAccessoryServerRef *svr,
+                    mgos::hap::Accessory *existing_acc = nullptr);
 
 }  // namespace hap
 }  // namespace shelly

--- a/src/shelly_main.cpp
+++ b/src/shelly_main.cpp
@@ -276,9 +276,18 @@ void CreateHAPSwitch(int id, const struct mgos_config_sw *sw_cfg,
                                  sw_cfg->name, GetIdentifyCB(), svr));
     acc->AddHAPService(&mgos_hap_accessory_information_service);
     acc->AddService(sw2);
+    if (sw_cfg->in_mode == (int) InMode::kDetached &&
+        in_cfg->type == (int) Component::Type::kDoorbell &&
+        sw_cfg->svc_type == 2 /* Lock */) {
+      // Add doorbell service to the same accessory as the lock.
+      // This makes iOS show the lock tile in the doorbell notification.
+      hap::CreateHAPInput(id, in_cfg, comps, accs, svr, acc.get());
+    }
     accs->push_back(std::move(acc));
   }
-  if (sw_cfg->in_mode == (int) InMode::kDetached) {
+  if (sw_cfg->in_mode == (int) InMode::kDetached &&
+      (in_cfg->type != (int) Component::Type::kDoorbell ||
+       sw_cfg->svc_type != 2)) {
     hap::CreateHAPInput(id, in_cfg, comps, accs, svr);
   }
 }


### PR DESCRIPTION
Hello,

When a switch is configured as Lock with a detached Doorbell input, the doorbell service is now added to the same HAP accessory as the lock. This makes iOS show the lock control in the doorbell notification, allowing to unlock directly.

| Before | After |
|--------|-------|
|![before](https://github.com/user-attachments/assets/876f6760-2784-41c2-8611-4cbeb7d16511)|![after](https://github.com/user-attachments/assets/69ad47d2-4059-461d-b0b0-7987ac04bfc8) |


Settings:
<img width="508" height="784" alt="Screenshot 2026-03-16 at 22 53 45" src="https://github.com/user-attachments/assets/de093d85-d3a6-4297-a87e-e9999927cf38" />


Fixes #1365 